### PR TITLE
refactor: move env variables to input section

### DIFF
--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -14,6 +14,43 @@ on:
       tag:
         required: true
         type: string
+      # Environment variables
+      apps-plugin:
+        required: true
+        type: string
+      chatbox-plugin:
+        required: true
+        type: string
+      database-logs:
+        required: true
+        type: string
+      embedded-link-item-plugin:
+        required: true
+        type: string
+      node-env:
+        required: true
+        type: string
+      node-env-container-2:
+        required: true
+        type: string
+      public-plugin:
+        required: true
+        type: string
+      roarr-log:
+        required: true
+        type: string
+      s3-file-item-plugin:
+        required: true
+        type: string
+      save-actions:
+        required: true
+        type: string
+      token-based-auth:
+        required: true
+        type: string
+      websockets-plugin:
+        required: true
+        type: string
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -43,7 +80,7 @@ on:
       # Environment variables
       apps-jwt-secret:
         required: true
-      apps-plugin:
+      apps-publisher-id:
         required: true
       auth-client-host:
         required: true
@@ -53,21 +90,15 @@ on:
         required: true
       avatars-path-prefix:
         required: true
-      chatbox-plugin:
-        required: true
       client-host:
         required: true
       cookie-domain:
         required: true
       cors-origin-regex:
         required: true
-      database-logs:
-        required: true
       email-links-host:
         required: true
       embedded-link-item-iframely-href-origin:
-        required: true
-      embedded-link-item-plugin:
         required: true
       file-storage-root-path:
         required: true
@@ -91,15 +122,9 @@ on:
         required: true
       mailer-config-username:
         required: true
-      node-env:
-        required: true
-      node-env-container-2:
-        required: true
       pg-connection-uri:
         required: true
       port:
-        required: true
-      public-plugin:
         required: true
       public-tag-id:
         required: true
@@ -117,19 +142,13 @@ on:
         required: true
       refresh-token-jwt-secret:
         required: true
-      roarr-log:
-        required: true
       s3-file-item-access-key-id:
         required: true
       s3-file-item-bucket:
         required: true
-      s3-file-item-access-plugin:
-        required: true
       s3-file-item-region:
         required: true
       s3-file-item-secret-access-key:
-        required: true
-      save-actions:
         required: true
       secure-session-secret-key:
         required: true
@@ -138,10 +157,6 @@ on:
       stripe-default-plan-price-id:
         required: true
       thumbnails-path-prefix:
-        required: true
-      token-based-auth:
-        required: true
-      websockets-plugin:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -213,19 +228,20 @@ jobs:
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           environment-variables: |
             APPS_JWT_SECRET=${{ secrets.apps-jwt-secret }}
-            APPS_PLUGIN=${{ secrets.apps-plugin }}
+            APPS_PLUGIN=${{ inputs.apps-plugin }}
+            APPS_PUBLISHER_ID=${{ secrets.apps-publisher-id }}
             AUTH_CLIENT_HOST=${{ secrets.auth-client-host }}
             AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.auth-token-expiration-in-minutes }}
             AUTH_TOKEN_JWT_SECRET=${{ secrets.auth-token-jwt-secret }}
             AVATARS_PATH_PREFIX=${{ secrets.avatars-path-prefix }}
-            CHATBOX_PLUGIN=${{ secrets.chatbox-plugin }}
+            CHATBOX_PLUGIN=${{ inputs.chatbox-plugin }}
             CLIENT_HOST=${{ secrets.client-host }}
             COOKIE_DOMAIN=${{ secrets.cookie-domain }}
             CORS_ORIGIN_REGEX=${{ secrets.cors-origin-regex }}
-            DATABASE_LOGS=${{ secrets.database-logs }}
+            DATABASE_LOGS=${{ inputs.database-logs }}
             EMAIL_LINKS_HOST=${{ secrets.email-links-host }}
             EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ secrets.embedded-link-item-iframely-href-origin }}
-            EMBEDDED_LINK_ITEM_PLUGIN=${{ secrets.embedded-link-item-plugin }}
+            EMBEDDED_LINK_ITEM_PLUGIN=${{ inputs.embedded-link-item-plugin }}
             FILE_STORAGE_ROOT_PATH=${{ secrets.file-storage-root-path }}
             FILES_PATH_PREFIX=${{ secrets.files-path-prefix }}
             HIDDEN_TAG_ID=${{ secrets.hidden-tag-id }}
@@ -237,10 +253,10 @@ jobs:
             MAILER_CONFIG_PASSWORD=${{ secrets.mailer-config-password }}
             MAILER_CONFIG_SMTP_HOST=${{ secrets.mailer-config-smtp-host }}
             MAILER_CONFIG_USERNAME=${{ secrets.mailer-config-username }}
-            NODE_ENV=${{ secrets.node-env }}
+            NODE_ENV=${{ inputs.node-env }}
             PG_CONNECTION_URI=${{ secrets.pg-connection-uri }}
             PORT=${{ secrets.port }}
-            PUBLIC_PLUGIN=${{ secrets.public-plugin }}
+            PUBLIC_PLUGIN=${{ inputs.public-plugin }}
             PUBLIC_TAG_ID=${{ secrets.public-tag-id }}
             PUBLISHED_TAG_ID=${{ secrets.published-tag-id }}
             REDIS_HOST=${{ secrets.redis-host }}
@@ -249,19 +265,19 @@ jobs:
             REDIS_USERNAME=${{ secrets.redis-username }}
             REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.refresh-token-expiration-in-minutes }}
             REFRESH_TOKEN_JWT_SECRET=${{ secrets.refresh-token-jwt-secret }}
-            ROARR_LOG=${{ secrets.roarr-log }}
+            ROARR_LOG=${{ inputs.roarr-log }}
             S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.s3-file-item-access-key-id }}
             S3_FILE_ITEM_BUCKET=${{ secrets.s3-file-item-bucket }}
-            S3_FILE_ITEM_PLUGIN=${{ secrets.s3-file-item-access-plugin }}
+            S3_FILE_ITEM_PLUGIN=${{ inputs.s3-file-item-plugin }}
             S3_FILE_ITEM_REGION=${{ secrets.s3-file-item-region }}
             S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.s3-file-item-secret-access-key }}
-            SAVE_ACTIONS=${{ secrets.save-actions }}
+            SAVE_ACTIONS=${{ inputs.save-actions }}
             SECURE_SESSION_SECRET_KEY=${{ secrets.secure-session-secret-key }}
             STRIPE_SECRET_KEY=${{ secrets.stripe-secret-key }}
             STRIPE_DEFAULT_PLAN_PRICE_ID=${{ secrets.stripe-default-plan-price-id }}
             THUMBNAILS_PATH_PREFIX=${{ secrets.thumbnails-path-prefix }}
-            TOKEN_BASED_AUTH=${{ secrets.token-based-auth }}
-            WEBSOCKETS_PLUGIN=${{ secrets.websockets-plugin }}
+            TOKEN_BASED_AUTH=${{ inputs.token-based-auth }}
+            WEBSOCKETS_PLUGIN=${{ inputs.websockets-plugin }}
 
     # Insert a second container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with second container
@@ -272,7 +288,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ secrets.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-container-2 }}
 
     # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with third container

--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -30,7 +30,7 @@ on:
       node-env:
         required: true
         type: string
-      node-env-container-2:
+      node-env-iframely:
         required: true
         type: string
       public-plugin:
@@ -288,7 +288,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ inputs.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-iframely }}
 
     # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with third container

--- a/.github/workflows/cdeployment-ecs-backend.yml
+++ b/.github/workflows/cdeployment-ecs-backend.yml
@@ -10,6 +10,43 @@ on:
       ecs-task-definition:
         required: true
         type: string
+      # Environment variables
+      apps-plugin:
+        required: true
+        type: string
+      chatbox-plugin:
+        required: true
+        type: string
+      database-logs:
+        required: true
+        type: string
+      embedded-link-item-plugin:
+        required: true
+        type: string
+      node-env:
+        required: true
+        type: string
+      node-env-container-2:
+        required: true
+        type: string
+      public-plugin:
+        required: true
+        type: string
+      roarr-log:
+        required: true
+        type: string
+      s3-file-item-plugin:
+        required: true
+        type: string
+      save-actions:
+        required: true
+        type: string
+      token-based-auth:
+        required: true
+        type: string
+      websockets-plugin:
+        required: true
+        type: string
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -39,7 +76,7 @@ on:
       # Environment variables
       apps-jwt-secret:
         required: true
-      apps-plugin:
+      apps-publisher-id:
         required: true
       auth-client-host:
         required: true
@@ -49,21 +86,15 @@ on:
         required: true
       avatars-path-prefix:
         required: true
-      chatbox-plugin:
-        required: true
       client-host:
         required: true
       cookie-domain:
         required: true
       cors-origin-regex:
         required: true
-      database-logs:
-        required: true
       email-links-host:
         required: true
       embedded-link-item-iframely-href-origin:
-        required: true
-      embedded-link-item-plugin:
         required: true
       file-storage-root-path:
         required: true
@@ -87,15 +118,9 @@ on:
         required: true
       mailer-config-username:
         required: true
-      node-env:
-        required: true
-      node-env-container-2:
-        required: true
       pg-connection-uri:
         required: true
       port:
-        required: true
-      public-plugin:
         required: true
       public-tag-id:
         required: true
@@ -113,19 +138,13 @@ on:
         required: true
       refresh-token-jwt-secret:
         required: true
-      roarr-log:
-        required: true
       s3-file-item-access-key-id:
         required: true
       s3-file-item-bucket:
         required: true
-      s3-file-item-access-plugin:
-        required: true
       s3-file-item-region:
         required: true
       s3-file-item-secret-access-key:
-        required: true
-      save-actions:
         required: true
       secure-session-secret-key:
         required: true
@@ -134,10 +153,6 @@ on:
       stripe-default-plan-price-id:
         required: true
       thumbnails-path-prefix:
-        required: true
-      token-based-auth:
-        required: true
-      websockets-plugin:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -210,19 +225,20 @@ jobs:
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           environment-variables: |
             APPS_JWT_SECRET=${{ secrets.apps-jwt-secret }}
-            APPS_PLUGIN=${{ secrets.apps-plugin }}
+            APPS_PLUGIN=${{ inputs.apps-plugin }}
+            APPS_PUBLISHER_ID=${{ secrets.apps-publisher-id }}
             AUTH_CLIENT_HOST=${{ secrets.auth-client-host }}
             AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.auth-token-expiration-in-minutes }}
             AUTH_TOKEN_JWT_SECRET=${{ secrets.auth-token-jwt-secret }}
             AVATARS_PATH_PREFIX=${{ secrets.avatars-path-prefix }}
-            CHATBOX_PLUGIN=${{ secrets.chatbox-plugin }}
+            CHATBOX_PLUGIN=${{ inputs.chatbox-plugin }}
             CLIENT_HOST=${{ secrets.client-host }}
             COOKIE_DOMAIN=${{ secrets.cookie-domain }}
             CORS_ORIGIN_REGEX=${{ secrets.cors-origin-regex }}
-            DATABASE_LOGS=${{ secrets.database-logs }}
+            DATABASE_LOGS=${{ inputs.database-logs }}
             EMAIL_LINKS_HOST=${{ secrets.email-links-host }}
             EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ secrets.embedded-link-item-iframely-href-origin }}
-            EMBEDDED_LINK_ITEM_PLUGIN=${{ secrets.embedded-link-item-plugin }}
+            EMBEDDED_LINK_ITEM_PLUGIN=${{ inputs.embedded-link-item-plugin }}
             FILE_STORAGE_ROOT_PATH=${{ secrets.file-storage-root-path }}
             FILES_PATH_PREFIX=${{ secrets.files-path-prefix }}
             HIDDEN_TAG_ID=${{ secrets.hidden-tag-id }}
@@ -234,10 +250,10 @@ jobs:
             MAILER_CONFIG_PASSWORD=${{ secrets.mailer-config-password }}
             MAILER_CONFIG_SMTP_HOST=${{ secrets.mailer-config-smtp-host }}
             MAILER_CONFIG_USERNAME=${{ secrets.mailer-config-username }}
-            NODE_ENV=${{ secrets.node-env }}
+            NODE_ENV=${{ inputs.node-env }}
             PG_CONNECTION_URI=${{ secrets.pg-connection-uri }}
             PORT=${{ secrets.port }}
-            PUBLIC_PLUGIN=${{ secrets.public-plugin }}
+            PUBLIC_PLUGIN=${{ inputs.public-plugin }}
             PUBLIC_TAG_ID=${{ secrets.public-tag-id }}
             PUBLISHED_TAG_ID=${{ secrets.published-tag-id }}
             REDIS_HOST=${{ secrets.redis-host }}
@@ -246,19 +262,19 @@ jobs:
             REDIS_USERNAME=${{ secrets.redis-username }}
             REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.refresh-token-expiration-in-minutes }}
             REFRESH_TOKEN_JWT_SECRET=${{ secrets.refresh-token-jwt-secret }}
-            ROARR_LOG=${{ secrets.roarr-log }}
+            ROARR_LOG=${{ inputs.roarr-log }}
             S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.s3-file-item-access-key-id }}
             S3_FILE_ITEM_BUCKET=${{ secrets.s3-file-item-bucket }}
-            S3_FILE_ITEM_PLUGIN=${{ secrets.s3-file-item-access-plugin }}
+            S3_FILE_ITEM_PLUGIN=${{ inputs.s3-file-item-plugin }}
             S3_FILE_ITEM_REGION=${{ secrets.s3-file-item-region }}
             S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.s3-file-item-secret-access-key }}
-            SAVE_ACTIONS=${{ secrets.save-actions }}
+            SAVE_ACTIONS=${{ inputs.save-actions }}
             SECURE_SESSION_SECRET_KEY=${{ secrets.secure-session-secret-key }}
             STRIPE_SECRET_KEY=${{ secrets.stripe-secret-key }}
             STRIPE_DEFAULT_PLAN_PRICE_ID=${{ secrets.stripe-default-plan-price-id }}
             THUMBNAILS_PATH_PREFIX=${{ secrets.thumbnails-path-prefix }}
-            TOKEN_BASED_AUTH=${{ secrets.token-based-auth }}
-            WEBSOCKETS_PLUGIN=${{ secrets.websockets-plugin }}
+            TOKEN_BASED_AUTH=${{ inputs.token-based-auth }}
+            WEBSOCKETS_PLUGIN=${{ inputs.websockets-plugin }}
 
     # Insert a second container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with second container
@@ -269,7 +285,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ secrets.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-container-2 }}
 
     # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with third container

--- a/.github/workflows/cdeployment-ecs-backend.yml
+++ b/.github/workflows/cdeployment-ecs-backend.yml
@@ -26,7 +26,7 @@ on:
       node-env:
         required: true
         type: string
-      node-env-container-2:
+      node-env-iframely:
         required: true
         type: string
       public-plugin:
@@ -285,7 +285,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ inputs.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-iframely }}
 
     # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
     - name: Modify Amazon ECS task definition with third container

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -10,6 +10,43 @@ on:
       ecs-task-definition:
         required: true
         type: string
+      # Environment variables
+      apps-plugin:
+        required: true
+        type: string
+      chatbox-plugin:
+        required: true
+        type: string
+      database-logs:
+        required: true
+        type: string
+      embedded-link-item-plugin:
+        required: true
+        type: string
+      node-env:
+        required: true
+        type: string
+      node-env-container-2:
+        required: true
+        type: string
+      public-plugin:
+        required: true
+        type: string
+      roarr-log:
+        required: true
+        type: string
+      s3-file-item-plugin:
+        required: true
+        type: string
+      save-actions:
+        required: true
+        type: string
+      token-based-auth:
+        required: true
+        type: string
+      websockets-plugin:
+        required: true
+        type: string
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -39,7 +76,7 @@ on:
       # Environment variables
       apps-jwt-secret:
         required: true
-      apps-plugin:
+      apps-publisher-id:
         required: true
       auth-client-host:
         required: true
@@ -49,21 +86,15 @@ on:
         required: true
       avatars-path-prefix:
         required: true
-      chatbox-plugin:
-        required: true
       client-host:
         required: true
       cookie-domain:
         required: true
       cors-origin-regex:
         required: true
-      database-logs:
-        required: true
       email-links-host:
         required: true
       embedded-link-item-iframely-href-origin:
-        required: true
-      embedded-link-item-plugin:
         required: true
       file-storage-root-path:
         required: true
@@ -87,15 +118,9 @@ on:
         required: true
       mailer-config-username:
         required: true
-      node-env:
-        required: true
-      node-env-container-2:
-        required: true
       pg-connection-uri:
         required: true
       port:
-        required: true
-      public-plugin:
         required: true
       public-tag-id:
         required: true
@@ -113,19 +138,13 @@ on:
         required: true
       refresh-token-jwt-secret:
         required: true
-      roarr-log:
-        required: true
       s3-file-item-access-key-id:
         required: true
       s3-file-item-bucket:
         required: true
-      s3-file-item-access-plugin:
-        required: true
       s3-file-item-region:
         required: true
       s3-file-item-secret-access-key:
-        required: true
-      save-actions:
         required: true
       secure-session-secret-key:
         required: true
@@ -134,10 +153,6 @@ on:
       stripe-default-plan-price-id:
         required: true
       thumbnails-path-prefix:
-        required: true
-      token-based-auth:
-        required: true
-      websockets-plugin:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -247,19 +262,20 @@ jobs:
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           environment-variables: |
             APPS_JWT_SECRET=${{ secrets.apps-jwt-secret }}
-            APPS_PLUGIN=${{ secrets.apps-plugin }}
+            APPS_PLUGIN=${{ inputs.apps-plugin }}
+            APPS_PUBLISHER_ID=${{ secrets.apps-publisher-id }}
             AUTH_CLIENT_HOST=${{ secrets.auth-client-host }}
             AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.auth-token-expiration-in-minutes }}
             AUTH_TOKEN_JWT_SECRET=${{ secrets.auth-token-jwt-secret }}
-            AVATARS_PATH_PREFIX=${{ secrets.avatars-path-prefix }}
-            CHATBOX_PLUGIN=${{ secrets.chatbox-plugin }}
+            AVATARS_PATH_PREFIX=${{ inputs.avatars-path-prefix }}
+            CHATBOX_PLUGIN=${{ inputs.chatbox-plugin }}
             CLIENT_HOST=${{ secrets.client-host }}
             COOKIE_DOMAIN=${{ secrets.cookie-domain }}
             CORS_ORIGIN_REGEX=${{ secrets.cors-origin-regex }}
-            DATABASE_LOGS=${{ secrets.database-logs }}
+            DATABASE_LOGS=${{ inputs.database-logs }}
             EMAIL_LINKS_HOST=${{ secrets.email-links-host }}
             EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ secrets.embedded-link-item-iframely-href-origin }}
-            EMBEDDED_LINK_ITEM_PLUGIN=${{ secrets.embedded-link-item-plugin }}
+            EMBEDDED_LINK_ITEM_PLUGIN=${{ inputs.embedded-link-item-plugin }}
             FILE_STORAGE_ROOT_PATH=${{ secrets.file-storage-root-path }}
             FILES_PATH_PREFIX=${{ secrets.files-path-prefix }}
             HIDDEN_TAG_ID=${{ secrets.hidden-tag-id }}
@@ -271,10 +287,10 @@ jobs:
             MAILER_CONFIG_PASSWORD=${{ secrets.mailer-config-password }}
             MAILER_CONFIG_SMTP_HOST=${{ secrets.mailer-config-smtp-host }}
             MAILER_CONFIG_USERNAME=${{ secrets.mailer-config-username }}
-            NODE_ENV=${{ secrets.node-env }}
+            NODE_ENV=${{ inputs.node-env }}
             PG_CONNECTION_URI=${{ secrets.pg-connection-uri }}
             PORT=${{ secrets.port }}
-            PUBLIC_PLUGIN=${{ secrets.public-plugin }}
+            PUBLIC_PLUGIN=${{ inputs.public-plugin }}
             PUBLIC_TAG_ID=${{ secrets.public-tag-id }}
             PUBLISHED_TAG_ID=${{ secrets.published-tag-id }}
             REDIS_HOST=${{ secrets.redis-host }}
@@ -283,19 +299,19 @@ jobs:
             REDIS_USERNAME=${{ secrets.redis-username }}
             REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.refresh-token-expiration-in-minutes }}
             REFRESH_TOKEN_JWT_SECRET=${{ secrets.refresh-token-jwt-secret }}
-            ROARR_LOG=${{ secrets.roarr-log }}
+            ROARR_LOG=${{ inputs.roarr-log }}
             S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.s3-file-item-access-key-id }}
             S3_FILE_ITEM_BUCKET=${{ secrets.s3-file-item-bucket }}
-            S3_FILE_ITEM_PLUGIN=${{ secrets.s3-file-item-access-plugin }}
+            S3_FILE_ITEM_PLUGIN=${{ inputs.s3-file-item-plugin }}
             S3_FILE_ITEM_REGION=${{ secrets.s3-file-item-region }}
             S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.s3-file-item-secret-access-key }}
-            SAVE_ACTIONS=${{ secrets.save-actions }}
+            SAVE_ACTIONS=${{ inputs.save-actions }}
             SECURE_SESSION_SECRET_KEY=${{ secrets.secure-session-secret-key }}
             STRIPE_SECRET_KEY=${{ secrets.stripe-secret-key }}
             STRIPE_DEFAULT_PLAN_PRICE_ID=${{ secrets.stripe-default-plan-price-id }}
             THUMBNAILS_PATH_PREFIX=${{ secrets.thumbnails-path-prefix }}
-            TOKEN_BASED_AUTH=${{ secrets.token-based-auth }}
-            WEBSOCKETS_PLUGIN=${{ secrets.websockets-plugin }}
+            TOKEN_BASED_AUTH=${{ inputs.token-based-auth }}
+            WEBSOCKETS_PLUGIN=${{ inputs.websockets-plugin }}
 
     # Modify Amazon ECS task definition with second container
     - name: Modify Amazon ECS task definition
@@ -306,7 +322,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ secrets.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-container-2 }}
 
     # Modify Amazon ECS task definition with third container
     - name: Modify Amazon ECS task definition

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -26,7 +26,7 @@ on:
       node-env:
         required: true
         type: string
-      node-env-container-2:
+      node-env-iframely:
         required: true
         type: string
       public-plugin:
@@ -322,7 +322,7 @@ jobs:
           container-name: ${{ secrets.container-name-iframely }}
           image: ${{ secrets.container-image-iframely}}
           environment-variables: |
-            NODE_ENV=${{ inputs.node-env-container-2 }}
+            NODE_ENV=${{ inputs.node-env-iframely }}
 
     # Modify Amazon ECS task definition with third container
     - name: Modify Amazon ECS task definition

--- a/caller-workflow-templates/cdelivery-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cdelivery-ecs-backend-caller.yml
@@ -17,6 +17,18 @@ jobs:
     with:
       ecs-task-definition:
       tag: ${{ github.event.client_payload.tag }}
+      apps-plugin: true
+      chatbox-plugin: true
+      database-logs: false
+      embedded-link-item-plugin: true
+      node-env: production
+      node-env-container-2: production
+      public-plugin: true
+      roarr-log: false
+      s3-file-item-plugin: true
+      save-actions: true
+      token-based-auth: true
+      websockets-plugin: true
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:
@@ -25,25 +37,22 @@ jobs:
       ecs-cluster:
       ecs-service:
       ecr-repository:
-      container-name-graasp:
+      container-name-graasp:        
       container-name-iframely:
       container-name-classifier:
       container-image-iframely:
       container-image-classifier:
       apps-jwt-secret:
-      apps-plugin:
+      apps-publisher-id:
       auth-client-host:
       auth-token-expiration-in-minutes:
       auth-token-jwt-secret:
       avatars-path-prefix:
-      chatbox-plugin:
       client-host:
       cookie-domain:
       cors-origin-regex:
-      database-logs:
       email-links-host:
       embedded-link-item-iframely-href-origin:
-      embedded-link-item-plugin:
       file-storage-root-path:
       files-path-prefix:
       hidden-tag-id:
@@ -55,11 +64,8 @@ jobs:
       mailer-config-password:
       mailer-config-smtp-host:
       mailer-config-username:
-      node-env:
-      node-env-container-2:
       pg-connection-uri:
       port:
-      public-plugin:
       public-tag-id:
       published-tag-id:
       redis-host:
@@ -67,16 +73,11 @@ jobs:
       redis-username:
       refresh-token-expiration-in-minutes:
       refresh-token-jwt-secret:
-      roarr-log:
       s3-file-item-access-key-id:
       s3-file-item-bucket:
-      s3-file-item-access-plugin:
       s3-file-item-region:
       s3-file-item-secret-access-key:
-      save-actions:
       secure-session-secret-key:
       stripe-secret-key:
       stripe-default-plan-price-id:
       thumbnails-path-prefix:
-      token-based-auth:
-      websockets-plugin:

--- a/caller-workflow-templates/cdelivery-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cdelivery-ecs-backend-caller.yml
@@ -22,7 +22,7 @@ jobs:
       database-logs: false
       embedded-link-item-plugin: true
       node-env: production
-      node-env-container-2: production
+      node-env-iframely: production
       public-plugin: true
       roarr-log: false
       s3-file-item-plugin: true

--- a/caller-workflow-templates/cdeployment-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cdeployment-ecs-backend-caller.yml
@@ -17,6 +17,18 @@ jobs:
     with:
       ecs-task-definition:
       tag: ${{ github.event.client_payload.tag }}
+      apps-plugin: true
+      chatbox-plugin: true
+      database-logs: false
+      embedded-link-item-plugin: true
+      node-env: production
+      node-env-container-2: production
+      public-plugin: true
+      roarr-log: false
+      s3-file-item-plugin: true
+      save-actions: true
+      token-based-auth: true
+      websockets-plugin: true
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:
@@ -24,26 +36,23 @@ jobs:
       aws-region:
       ecs-cluster:
       ecs-service:
-      container-name-graasp:
       ecr-repository:
+      container-name-graasp:        
       container-name-iframely:
       container-name-classifier:
       container-image-iframely:
       container-image-classifier:
       apps-jwt-secret:
-      apps-plugin:
+      apps-publisher-id:
       auth-client-host:
       auth-token-expiration-in-minutes:
       auth-token-jwt-secret:
       avatars-path-prefix:
-      chatbox-plugin:
       client-host:
       cookie-domain:
       cors-origin-regex:
-      database-logs:
       email-links-host:
       embedded-link-item-iframely-href-origin:
-      embedded-link-item-plugin:
       file-storage-root-path:
       files-path-prefix:
       hidden-tag-id:
@@ -55,11 +64,8 @@ jobs:
       mailer-config-password:
       mailer-config-smtp-host:
       mailer-config-username:
-      node-env:
-      node-env-container-2:
       pg-connection-uri:
       port:
-      public-plugin:
       public-tag-id:
       published-tag-id:
       redis-host:
@@ -67,16 +73,11 @@ jobs:
       redis-username:
       refresh-token-expiration-in-minutes:
       refresh-token-jwt-secret:
-      roarr-log:
       s3-file-item-access-key-id:
       s3-file-item-bucket:
-      s3-file-item-access-plugin:
       s3-file-item-region:
       s3-file-item-secret-access-key:
-      save-actions:
       secure-session-secret-key:
       stripe-secret-key:
       stripe-default-plan-price-id:
       thumbnails-path-prefix:
-      token-based-auth:
-      websockets-plugin:

--- a/caller-workflow-templates/cdeployment-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cdeployment-ecs-backend-caller.yml
@@ -22,7 +22,7 @@ jobs:
       database-logs: false
       embedded-link-item-plugin: true
       node-env: production
-      node-env-container-2: production
+      node-env-iframely: production
       public-plugin: true
       roarr-log: false
       s3-file-item-plugin: true

--- a/caller-workflow-templates/cintegration-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-backend-caller.yml
@@ -20,6 +20,18 @@ jobs:
     # Replace input ecs-task-definition with template file. Format: '.aws/<name>-dev.json'
     with:
       ecs-task-definition:
+      apps-plugin: true
+      chatbox-plugin: true
+      database-logs: false
+      embedded-link-item-plugin: true
+      node-env: production
+      node-env-container-2: production
+      public-plugin: true
+      roarr-log: false
+      s3-file-item-plugin: true
+      save-actions: true
+      token-based-auth: true
+      websockets-plugin: true
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:
@@ -27,26 +39,23 @@ jobs:
       aws-region:
       ecs-cluster:
       ecs-service:
-      container-name-graasp:
       ecr-repository:
+      container-name-graasp:        
       container-name-iframely:
       container-name-classifier:
       container-image-iframely:
       container-image-classifier:
       apps-jwt-secret:
-      apps-plugin:
+      apps-publisher-id:
       auth-client-host:
       auth-token-expiration-in-minutes:
       auth-token-jwt-secret:
       avatars-path-prefix:
-      chatbox-plugin:
       client-host:
       cookie-domain:
       cors-origin-regex:
-      database-logs:
       email-links-host:
       embedded-link-item-iframely-href-origin:
-      embedded-link-item-plugin:
       file-storage-root-path:
       files-path-prefix:
       hidden-tag-id:
@@ -58,11 +67,8 @@ jobs:
       mailer-config-password:
       mailer-config-smtp-host:
       mailer-config-username:
-      node-env:
-      node-env-container-2:
       pg-connection-uri:
       port:
-      public-plugin:
       public-tag-id:
       published-tag-id:
       redis-host:
@@ -70,16 +76,11 @@ jobs:
       redis-username:
       refresh-token-expiration-in-minutes:
       refresh-token-jwt-secret:
-      roarr-log:
       s3-file-item-access-key-id:
       s3-file-item-bucket:
-      s3-file-item-access-plugin:
       s3-file-item-region:
       s3-file-item-secret-access-key:
-      save-actions:
       secure-session-secret-key:
       stripe-secret-key:
       stripe-default-plan-price-id:
       thumbnails-path-prefix:
-      token-based-auth:
-      websockets-plugin:

--- a/caller-workflow-templates/cintegration-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-backend-caller.yml
@@ -25,7 +25,7 @@ jobs:
       database-logs: false
       embedded-link-item-plugin: true
       node-env: production
-      node-env-container-2: production
+      node-env-iframely: production
       public-plugin: true
       roarr-log: false
       s3-file-item-plugin: true


### PR DESCRIPTION
I refactored the backend workflows and moved some env variables to the inputs section. This is due to the restriction the repository has for the amount of secrets (100 in total). Therefore, the variables which are not considered secrets have been moved to the inputs section