### PR TITLE
48 refactor ci pipeline

### DIFF
--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -188,7 +188,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called: build-deploy and test
+# This workflow is made up of one jobs called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:
@@ -339,20 +339,3 @@ jobs:
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
           wait-for-service-stability: true       
-
-  test:
-    name: Test
-    needs: build-deploy
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ inputs.tag }}
-
-    # This step runs a single command to execute integation testing
-    - name: Test
-      run: |
-        echo "This is the integration test step"

--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -188,7 +188,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of one jobs called build-deploy
+# This workflow is made up of one job called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:

--- a/.github/workflows/cdelivery-ecs-explorer.yml
+++ b/.github/workflows/cdelivery-ecs-explorer.yml
@@ -62,7 +62,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called: build-deploy and test
+# This workflow is made up of one jobs called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:
@@ -143,20 +143,3 @@ jobs:
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
           wait-for-service-stability: true       
-
-  test:
-    name: Test
-    needs: build-deploy
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ inputs.tag }}
-
-    # This step runs a single command to execute integation testing
-    - name: Test
-      run: |
-        echo "This is the integration test step"

--- a/.github/workflows/cdelivery-ecs-explorer.yml
+++ b/.github/workflows/cdelivery-ecs-explorer.yml
@@ -62,7 +62,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of one jobs called build-deploy
+# This workflow is made up of one job called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:

--- a/.github/workflows/cdelivery-ecs.yml
+++ b/.github/workflows/cdelivery-ecs.yml
@@ -44,7 +44,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called: build-deploy and test
+# This workflow is made up of one jobs called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:
@@ -130,20 +130,3 @@ jobs:
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
           wait-for-service-stability: true       
-
-  test:
-    name: Test
-    needs: build-deploy
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ inputs.tag }}
-
-    # This step runs a single command to execute integation testing
-    - name: Test
-      run: |
-        echo "This is the integration test step"

--- a/.github/workflows/cdelivery-ecs.yml
+++ b/.github/workflows/cdelivery-ecs.yml
@@ -44,7 +44,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of one jobs called build-deploy
+# This workflow is made up of one job called build-deploy
 jobs:
   # Build image, push to ECR and deploy to staging environment
   build-deploy:

--- a/.github/workflows/cdelivery-s3-apps.yml
+++ b/.github/workflows/cdelivery-s3-apps.yml
@@ -48,7 +48,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called: build-deploy and test
+# This workflow is made up of one jobs called build-deploy
 jobs:
   # Build, sync with S3 and deploy to staging environment
   build-deploy:
@@ -108,20 +108,3 @@ jobs:
     - name: Invalidate cloudfront distribution
       id: invalidate-cloudfront
       run: aws cloudfront create-invalidation --distribution-id ${{ secrets.cloudfront-distribution-id }} --paths /${{ secrets.app-id }}/${{env.VERSION}}/*
-
-  test:
-    name: Test
-    needs: build-deploy
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ inputs.tag }}
-
-    # This step runs a single command to execute integation testing
-    - name: Test
-      run: |
-        echo "This is the integrations test step"

--- a/.github/workflows/cdelivery-s3-apps.yml
+++ b/.github/workflows/cdelivery-s3-apps.yml
@@ -48,7 +48,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of one jobs called build-deploy
+# This workflow is made up of one job called build-deploy
 jobs:
   # Build, sync with S3 and deploy to staging environment
   build-deploy:

--- a/.github/workflows/cdelivery-s3.yml
+++ b/.github/workflows/cdelivery-s3.yml
@@ -66,7 +66,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of one jobs called build-deploy
+# This workflow is made up of one job called build-deploy
 jobs:
   # Build, sync with S3 and deploy to staging environment
   build-deploy:

--- a/.github/workflows/cdelivery-s3.yml
+++ b/.github/workflows/cdelivery-s3.yml
@@ -66,7 +66,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called build-deploy and test
+# This workflow is made up of one jobs called build-deploy
 jobs:
   # Build, sync with S3 and deploy to staging environment
   build-deploy:
@@ -138,20 +138,3 @@ jobs:
     - name: Invalidate cloudfront distribution
       id: invalidate-cloudfront
       run: aws cloudfront create-invalidation --distribution-id ${{ secrets.cloudfront-distribution-id }} --paths "/*"
-    
-  test:
-    name: Test
-    needs: build-deploy
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ inputs.tag }}
-
-    # This step runs a single command to execute integation testing
-    - name: Test
-      run: |
-        echo "This is the integration test step"

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -201,7 +201,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called build and deploy
+# This workflow is made up of three jobs that run sequentially, called build test and deploy
 jobs:
   # Build image and cache dist directory
   build:

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -261,7 +261,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
+    if: ${{ (inputs.test-execution == 'true') ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -201,7 +201,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of three jobs that run sequentially, called build test and deploy
+# This workflow is made up of three jobs that run sequentially, called build, test, and deploy
 jobs:
   # Build image and cache dist directory
   build:
@@ -257,10 +257,10 @@ jobs:
         path: dist
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
 
-
   test:
     name: Test
     needs: build
+    # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
     if: inputs.test-execution == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -332,6 +332,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
+    # This job is executed only when the build job has been successful and either the user has manually dispatched the workflow or it is a push to the default branch (master). 
     if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -51,7 +51,7 @@ on:
         required: true
         type: string
       test-execution:
-        required: true
+        required: false
         type: boolean
         default: true
     # Define secrets which can be passed from the caller workflow

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -203,48 +203,60 @@ env:
 
 # This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
-  # Build image and push to ECR
+  # Build image and cache dist directory
   build:
     name: Build
-    if: ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master'))
     runs-on: ubuntu-latest
-    # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
-      tag: ${{ steps.tag-number.outputs.tag }}
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    # Set output variable tag with the current checked out ref
-    - name: Set Tag Number
-      id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-    # Configure AWS credential and region environment variables for use in next steps
-    - name: Configure AWS Credentials
-      id: configure-aws
-      uses: aws-actions/configure-aws-credentials@v1
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
       with:
-        aws-access-key-id: ${{ secrets.aws-access-key-id }}
-        aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-        aws-region: ${{ secrets.aws-region }}
+        node-version: 16.x
 
-    # Log in the local Docker client
-    - name: Login to Amazon ECR
-      id: login-ecr-build
-      uses: aws-actions/amazon-ecr-login@v1
-    
-    # Build and tag the docker image 
-    - name: Build, tag and push image to AWS ECR
-      id: build-image
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr-build.outputs.registry }}
-        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f .stagingcontainer/Dockerfile .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Install dependencies
+    - name: Install dependencies and build
+      run: yarn add --cached
+
+    # Build image
+    - name: Yarn build
+      run: yarn build --if-present
+
+    # Cache build to share it between jobs
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the branch and run_id to create a new build for every run.
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: dist
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+
 
   test:
     name: Test
@@ -285,11 +297,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
+    # Cache build to re-use it from previous jobs
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: dist
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+
     # Install dependencies
-    - name: yarn install and build
-      run: |
-        yarn
-        yarn build --if-present
+    - name: Install dependencies and build
+      run: yarn add --cached
 
     - name: yarn test
       run: 
@@ -314,13 +332,18 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
-    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
       uses: actions/checkout@v2
+
+    # Set output variable tag with the current checked out ref
+    - name: Set Tag Number
+      id: tag-number
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS credentials
@@ -335,6 +358,16 @@ jobs:
       id: login-ecr-deploy
       uses: aws-actions/amazon-ecr-login@v1
 
+    # Build and tag the docker image 
+    - name: Build, tag and push image to AWS ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr-deploy.outputs.registry }}
+        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f .stagingcontainer/Dockerfile .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
     # Insert a container image URI into template Amazon ECS task definition JSON file, creating a new task definition file.
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def-1
@@ -342,7 +375,7 @@ jobs:
       # Set environment variables required to create the task definition file. These are only available to this step
       env:
         ECR_REGISTRY: ${{ steps.login-ecr-deploy.outputs.registry }}
-        IMAGE_TAG: ${{ needs.build.outputs.tag }}
+        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
       with:
           task-definition: ${{ inputs.ecs-task-definition }}
           container-name: ${{ secrets.container-name-graasp }}

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -176,6 +176,11 @@ on:
       thumbnails-path-prefix:
         required: true
 
+# Saving computation time by stopping obsolete workflows
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 # Set environment variables that are available to the steps of all jobs in the workflow
 env:        
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -52,8 +52,8 @@ on:
         type: string
       test-execution:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -261,7 +261,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: inputs.test-execution == true
+    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -184,27 +184,10 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of three jobs that run sequentially, called test, build and deploy
+# This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
-  test:
-    name: Test
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    # This step runs a single command to execute unitary testing
-    - name: Test job
-      run: |
-        echo "This is the test job"
-
   # Build image and push to ECR
   build:
-    needs: test
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -50,6 +50,10 @@ on:
       websockets-plugin:
         required: true
         type: string
+      test-execution:
+        required: true
+        type: boolean
+        default: true
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -175,10 +179,18 @@ on:
         required: true
       thumbnails-path-prefix:
         required: true
+      mock-secure-session-secret-key:
+        required: true
+      mock-jwt-secret:
+        required: true
+      mock-refresh-token-jwt-secret:
+        required: true
+      mock-auth-token-jwt-secret:
+        required: true
 
 # Saving computation time by stopping obsolete workflows
 concurrency: 
-  group: ${{ github.workflow }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -194,6 +206,7 @@ jobs:
   # Build image and push to ECR
   build:
     name: Build
+    if: ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master'))
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
     outputs: 
@@ -233,10 +246,75 @@ jobs:
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f .stagingcontainer/Dockerfile .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
+  test:
+    name: Test
+    needs: build
+    if: inputs.test-execution == true
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Install dependencies
+    - name: yarn install and build
+      run: |
+        yarn
+        yarn build --if-present
+
+    - name: yarn test
+      run: 
+        yarn test
+      env:
+        CI: true
+        # random keys
+        SECURE_SESSION_SECRET_KEY: ${{ secrets.mock-secure-session-secret-key }}
+        JWT_SECRET: ${{ secrets.mock-jwt-secret }}
+        REFRESH_TOKEN_JWT_SECRET: ${{ secrets.mock-refresh-token-jwt-secret }}
+        AUTH_TOKEN_JWT_SECRET: ${{ secrets.mock-auth-token-jwt-secret }}
+        STRIPE_SECRET_KEY: ${{ secrets.stripe-secret-key }}
+        STRIPE_DEFAULT_PLAN_PRICE_ID: ${{ secrets.stripe-default-plan-price-id }}
+        FILE_STORAGE_ROOT_PATH: /
+        H5P_PATH_PREFIX: h5p
+        SAVE_ACTIONS: true
+        BUILDER_CLIENT_HOST: 'http://localhost:3111'
+        PLAYER_CLIENT_HOST: 'http://localhost:3112'
+        EXPLORER_CLIENT_HOST: 'http://localhost:3113'
+
   # Deploy to dev environment
   deploy: 
-    needs: build
     name: Deploy
+    needs: [build, test]
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -58,27 +58,10 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of three jobs that run sequentially, called test, build and deploy
+# This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
-  test:
-    name: Test
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    # This step runs a single command to execute unitary testing
-    - name: Test job
-      run: |
-        echo "This is the test job"
-
   # Build image and push to ECR
   build:
-    needs: test
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -88,7 +88,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of two jobs that run sequentially, called build and deploy
+# This workflow is made up of three jobs that run sequentially, called build, test, and deploy
 jobs:
   # Build image and cache next directory
   build:
@@ -159,6 +159,7 @@ jobs:
   test:
     name: Test
     needs: build
+    # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
     if: inputs.test-execution == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -251,6 +252,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
+    # This job is executed only when the build job has been successful and either the user has manually dispatched the workflow or it is a push to the default branch (master). 
     if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -160,7 +160,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: inputs.test-execution == true
+    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -225,7 +225,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
-    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -32,7 +32,7 @@ on:
         required: false
         type: string
       test-execution:
-        required: true
+        required: false
         type: boolean
         default: true
     # Define secrets which can be passed from the caller workflow

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -33,8 +33,8 @@ on:
         type: string
       test-execution:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -50,6 +50,11 @@ on:
       port:
         required: true
 
+# Saving computation time by stopping obsolete workflows
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 # Set environment variables that are available to the steps of all jobs in the workflow
 env:        
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -90,56 +90,11 @@ env:
 
 # This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
-  # Build image and push to ECR
+  # Build image and cache next directory
   build:
     name: Build
     runs-on: ubuntu-latest
-    # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
-      tag: ${{ steps.tag-number.outputs.tag }}
 
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-    
-    # Set output variable tag with the current checked out ref
-    - name: Set Tag Number
-      id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-    # Configure AWS credential and region environment variables for use in next steps
-    - name: Configure AWS Credentials
-      id: configure-aws
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.aws-access-key-id }}
-        aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-        aws-region: ${{ secrets.aws-region }}
-
-    # Log in the local Docker client
-    - name: Login to Amazon ECR
-      id: login-ecr-build
-      uses: aws-actions/amazon-ecr-login@v1
-
-    # Build and tag the docker image 
-    - name: Build, tag and push image to AWS ECR
-      id: build-image
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr-build.outputs.registry }}
-        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
-      run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-  test:
-    name: Test
-    needs: build
-    if: inputs.test-execution == true
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
@@ -172,16 +127,87 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    # Cache cypress binary to speed up workflow
+    # Cache cypress binary to speed up workflow. 
     # path: The file path on the runner to cache or restore.
     # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
-    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    # To avoid snowballing Cypress binary cache we use the exact key and not the restore keys.
     - name: Cache Cypress Binary
       id: cache-cypress-binary
       uses: actions/cache@v3
       with:
         path: '~/.cache/Cypress'
         key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+
+    # Install dependencies
+    - name: Install dependencies and build
+      run: yarn add --cached
+
+    # Build image
+    - name: Yarn build
+      run: yarn build
+
+    # Cache build to share it between jobs
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the branch and run_id to create a new build for every run.
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: '~/.next/'
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+
+  test:
+    name: Test
+    needs: build
+    if: inputs.test-execution == true
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        check-latest: true
+
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Cache cypress binary to speed up workflow
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+
+    # Cache build to re-use it from previous jobs
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: '~/.next/'
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
 
     # Install dependencies
     - name: Install dependencies
@@ -231,7 +257,12 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    # Set output variable tag with the current checked out ref
+    - name: Set Tag Number
+      id: tag-number
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS credentials
@@ -246,6 +277,16 @@ jobs:
       id: login-ecr-deploy
       uses: aws-actions/amazon-ecr-login@v1
 
+    # Build and tag the docker image 
+    - name: Build, tag and push image to AWS ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr-deploy.outputs.registry }}
+        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
     # Insert a container image URI into template Amazon ECS task definition JSON file, creating a new task definition file.
     - name: Fill Amazon ECS task definition
       id: task-def
@@ -253,7 +294,7 @@ jobs:
       # Set environment variables required to create the task definition file. These are only available to this step
       env:
         ECR_REGISTRY: ${{ steps.login-ecr-deploy.outputs.registry }}
-        IMAGE_TAG: ${{ needs.build.outputs.tag }}
+        IMAGE_TAG: ${{ steps.tag-number.outputs.tag }}
       with:
           task-definition: ${{ inputs.ecs-task-definition }}
           container-name: ${{ secrets.container-name-explorer }}

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -225,7 +225,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
-    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -160,7 +160,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
+    if: ${{ (inputs.test-execution == 'true') ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -10,6 +10,31 @@ on:
       ecs-task-definition:
         required: true
         type: string
+      graasper-id-test:
+        required: false
+        type: string
+      next-public-google-analytics-id-test:
+        required: false
+        type: string
+      next-public-published-tag-id-test:
+        required: false
+        type: string
+      next-public-api-host-test:
+        required: false
+        type: string
+      next-public-graasp-perform-host-test:
+        required: false
+        type: string
+      next-public-graasp-authentication-host-test:
+        required: false
+        type: string
+      next-public-node-env-test:
+        required: false
+        type: string
+      test-execution:
+        required: true
+        type: boolean
+        default: true
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -52,7 +77,7 @@ on:
 
 # Saving computation time by stopping obsolete workflows
 concurrency: 
-  group: ${{ github.workflow }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -107,10 +132,100 @@ jobs:
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
+  test:
+    name: Test
+    needs: build
+    if: inputs.test-execution == true
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        check-latest: true
+
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Cache cypress binary to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+
+    # Install dependencies
+    - name: Install dependencies
+      id: install
+      run: yarn add --cached
+
+    #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
+    - name: Cypress run
+      uses: cypress-io/github-action@v4
+      with:
+        install: false
+        config: baseUrl=http://localhost:3000
+        start: yarn start:ci
+        wait-on: 'http://localhost:3000'
+        wait-on-timeout: 180
+        browser: chrome
+        quiet: true
+      env:
+        GRAASPER_ID: ${{ inputs.graasper-id-test }}
+        NEXT_PUBLIC_API_HOST: ${{ inputs.next-public-api-host-test }}
+        NEXT_PUBLIC_GRAASP_AUTH_HOST: ${{ inputs.next-public-graasp-authentication-host-test }}
+        NEXT_PUBLIC_GRAASP_PERFORM_HOST: ${{ inputs.next-public-graasp-perform-host-test }}
+        NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${{ inputs.next-public-google-analytics-id-test }}
+        NEXT_PUBLIC_NODE_ENV: ${{ inputs.next-public-node-env-test }}
+        NEXT_PUBLIC_PUBLISHED_TAG_ID: ${{ inputs.next-public-published-tag-id-test }}
+
+    # after the test run completes
+    # store any screenshots
+    # NOTE: screenshots will be generated only if E2E test failed
+    # thus we store screenshots only on failures
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: cypress/screenshots
+
+    - name: coverage report
+      run: npx nyc report --reporter=text-summary
+
   # Deploy to dev environment
   deploy: 
-    needs: build
     name: Deploy
+    needs: [build, test]
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-ecs.yml
+++ b/.github/workflows/cintegration-ecs.yml
@@ -40,27 +40,10 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of three jobs that run sequentially, called test, build and deploy
+# This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
-  test:
-    name: Test
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    # This step runs a single command to execute unitary testing
-    - name: Test job
-      run: |
-        echo "This is the test job"
-
   # Build image and push to ECR
   build:
-    needs: test
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job

--- a/.github/workflows/cintegration-ecs.yml
+++ b/.github/workflows/cintegration-ecs.yml
@@ -32,6 +32,11 @@ on:
       # env-variable-name:
       #   required: true or false
 
+# Saving computation time by stopping obsolete workflows
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 # Set environment variables that are available to the steps of all jobs in the workflow
 env:        
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}

--- a/.github/workflows/cintegration-ecs.yml
+++ b/.github/workflows/cintegration-ecs.yml
@@ -10,6 +10,10 @@ on:
       ecs-task-definition:
         required: true
         type: string
+      test-execution:
+        required: false
+        type: string
+        default: 'true'
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -37,6 +37,11 @@ on:
       sentry-dsn:
         required: false
 
+# Saving computation time by stopping obsolete workflows
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 # Set environment variables that are available to the steps of all jobs in the workflow
 env:
   BUILD_FOLDER: '${{ inputs.build-folder }}'

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -35,7 +35,7 @@ on:
         required: false
         type: string
       test-execution:
-        required: true
+        required: false
         type: boolean
         default: true
     # Define secrets which can be passed from the caller workflow

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -241,7 +241,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
-    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -69,25 +69,42 @@ jobs:
         node-version: '16'
         check-latest: true
 
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
     # Cache dependencies to speed up workflow. Only for development branches
     # path: The file path on the runner to cache or restore.
     # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
     # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
     - name: Cache dependencies
-      id: cache-node-modules
-      if: (github.ref_name != 'main') && (github.ref_name != 'master')
+      id: cache-yarn
       uses: actions/cache@v3
       with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-            ${{ runner.os }}-modules-
+          ${{ runner.os }}-yarn-
 
-    # Install dependencies when the cache has not been retrieved
+    # Cache cypress binary to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # To avoid snowballing Cypress binary cache we use the exact key and not the restore keys.
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+
+    # Install dependencies
+    # The --cached flag with 'yarn add' is used  to use cached downloads (in the cache directory mentioned above) 
+    # during installation whenever possible instead of downloading them.
     - name: Install dependencies
       id: install
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: yarn install
+      run: yarn add --cached
 
     - name: Yarn build dev
       id: build-image

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -46,25 +46,9 @@ env:
 
 # This workflow is made up of three jobs that run sequentially, called test, build and deploy
 jobs:
-  test:
-    name: Test
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    # This step runs a single command to execute unitary testing
-    - name: Test job
-      run: |
-        echo "This is the test job"
 
   # Build and sync with S3
   build:
-    needs: test
     name: Build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -46,7 +46,6 @@ env:
 
 # This workflow is made up of three jobs that run sequentially, called test, build and deploy
 jobs:
-
   # Build and sync with S3
   build:
     name: Build
@@ -65,6 +64,26 @@ jobs:
         node-version: '16'
         check-latest: true
 
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-node-modules
+      if: (github.ref_name != 'main') && (github.ref_name != 'master')
+      uses: actions/cache@v3
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-modules-
+
+    # Install dependencies when the cache has not been retrieved
+    - name: Install dependencies
+      id: install
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: yarn install
+
     - name: Yarn build dev
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
@@ -74,9 +93,7 @@ jobs:
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
         REACT_APP_MOCK_API: false
       # Run a set of commands using the runners shell to perform install and build
-      run: |
-        yarn install
-        yarn run build
+      run: yarn run build
 
     # Cache build to share it between jobs
     # path: The file path on the runner to cache or restore.

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -36,8 +36,8 @@ on:
         type: string
       test-execution:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -152,6 +152,7 @@ jobs:
   test:
     name: Test
     needs: build
+    # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
     if: inputs.test-execution == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -241,6 +242,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
+    # This job is executed only when the build job has been successful and either the user has manually dispatched the workflow or it is a push to the default branch (main or master). 
     if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -16,6 +16,28 @@ on:
         required: false
         default: 'latest'
         type: string
+      api-host-test:
+        required: false
+        type: string
+      enable-mock-api-test:
+        required: false
+        type: string
+      graasp-app-id-test:
+        required: false
+        type: string
+      graasp-domain-test:
+        required: false
+        type: string
+      mock-api-test:
+        required: false
+        type: string
+      node-env-test:
+        required: false
+        type: string
+      test-execution:
+        required: true
+        type: boolean
+        default: true
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -39,7 +61,7 @@ on:
 
 # Saving computation time by stopping obsolete workflows
 concurrency: 
-  group: ${{ github.workflow }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -127,10 +149,99 @@ jobs:
         path: build
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
 
+  test:
+    name: Test
+    needs: build
+    if: inputs.test-execution == true
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        check-latest: true
+
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Cache cypress binary to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+
+    # Install dependencies
+    - name: Install dependencies
+      id: install
+      run: yarn add --cached
+
+    #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
+    - name: Cypress run
+      uses: cypress-io/github-action@v4
+      with:
+        install: false
+        config: baseUrl=http://localhost:3000
+        start: yarn start:ci
+        wait-on: 'http://localhost:3000'
+        wait-on-timeout: 180
+        browser: chrome
+        quiet: true
+      env:
+        REACT_APP_API_HOST: ${{ inputs.api-host-test }}
+        REACT_APP_ENABLE_MOCK_API: ${{ inputs.enable-mock-api-test }}
+        REACT_APP_GRAASP_APP_ID: ${{ inputs.graasp-app-id-test }}
+        REACT_APP_GRAASP_DOMAIN: ${{ inputs.graasp-domain-test }}
+        REACT_APP_MOCK_API: ${{ inputs.mock-api-test }}
+        NODE_ENV: ${{ inputs.node-env-test}}
+
+    # after the test run completes
+    # store any screenshots
+    # NOTE: screenshots will be generated only if E2E test failed
+    # thus we store screenshots only on failures
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: cypress/screenshots
+
+    - name: coverage report
+      run: npx nyc report --reporter=text-summary
+
   # Deploy to development environment
   deploy: 
-    needs: build
     name: Deploy
+    needs: [build, test]
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -78,6 +78,31 @@ jobs:
         yarn install
         yarn run build
 
+    # Cache build to share it between jobs
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the branch and run_id to create a new build for every run.
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+
+  # Deploy to development environment
+  deploy: 
+    needs: build
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    # Cache build to re-use it from previous jobs
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials
       id: configure-aws
@@ -98,20 +123,6 @@ jobs:
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 
-  # Deploy to development environment
-  deploy: 
-    needs: build
-    name: Deploy
-    runs-on: ubuntu-latest
-
-    steps:
-    # Configure AWS credential and region environment variables for use in next steps
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.aws-access-key-id }}
-        aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-        aws-region: ${{ secrets.aws-region }}
 
     # Create a new invalidation
     - name: Invalidate cloudfront distribution

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -153,7 +153,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
+    if: ${{ (inputs.test-execution == 'true') ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -153,7 +153,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: inputs.test-execution == true
+    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -151,6 +151,19 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-modules-
 
+    # Cache cypress binary to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-cypress-binary-
+
     # Install dependencies when the cache has not been retrieved
     - name: Install dependencies
       id: install
@@ -191,7 +204,7 @@ jobs:
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
 
   test:
-    name: Cypress
+    name: Test
     needs: build
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -172,7 +172,7 @@ jobs:
     # if: steps.cache-node-modules.outputs.cache-hit != 'true'
     - name: Install dependencies
       id: install
-      run: yarn --cached
+      run: yarn add --cached
 
     - name: Yarn build dev
       id: build-image
@@ -256,7 +256,7 @@ jobs:
     # if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
     - name: Install dependencies
       id: install
-      run: yarn --cached
+      run: yarn add --cached
 
     #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
     - name: Cypress run

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -88,6 +88,7 @@ jobs:
     # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
     - name: Cache dependencies
       id: cache-node-modules
+      if: (github.ref_name != 'main') && (github.ref_name != 'master')
       uses: actions/cache@v3
       with:
         path: '**/node_modules'

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -181,7 +181,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
+    if: ${{ (inputs.test-execution == 'true') ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -82,7 +82,7 @@ jobs:
         node-version: '16'
         check-latest: true
 
-    # Cache dependencies to speed up workflow
+    # Cache dependencies to speed up workflow. Only for development branches
     # path: The file path on the runner to cache or restore.
     # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
     # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
@@ -92,9 +92,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: '**/node_modules'
-        key: ${{ runner.os }}-modules-${{ github.ref_name }}-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-            ${{ runner.os }}-modules-${{ github.ref_name }}-
             ${{ runner.os }}-modules-
 
     # Install dependencies when the cache has not been retrieved
@@ -128,17 +127,13 @@ jobs:
 
     # Cache build to share it between jobs
     # path: The file path on the runner to cache or restore.
-    # key: Create cache key using the run_id to create a new build for every run.
-    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    # key: Create cache key using the branch and run_id to create a new build for every run.
     - name: Cache build
       id: cache-build
       uses: actions/cache@v3
       with:
         path: build
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ github.ref_name }}-
-          ${{ runner.os }}-build-
 
   # Deploy to development environment
   deploy: 
@@ -154,9 +149,6 @@ jobs:
       with:
         path: build
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ github.ref_name }}-
-          ${{ runner.os }}-build-
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -180,6 +180,7 @@ jobs:
   test:
     name: Test
     needs: build
+    # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
     if: inputs.test-execution == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -269,6 +270,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
+    # This job is executed only when the build job has been successful and either the user has manually dispatched the workflow or it is a push to the default branch (main or master). 
     if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -140,36 +140,40 @@ jobs:
       with:
         node-version: '16'
         check-latest: true
-        cache: 'yarn'
 
-    # # Cache dependencies to speed up workflow. Only for development branches
-    # # path: The file path on the runner to cache or restore.
-    # # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
-    # # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
-    # - name: Cache dependencies
-    #   id: cache-node-modules
-    #   if: (github.ref_name != 'main') && (github.ref_name != 'master')
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: '**/node_modules'
-    #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #         ${{ runner.os }}-modules-
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-    # Cache cypress binary to speed up workflow
+    # Cache dependencies to speed up workflow. Only for development branches
     # path: The file path on the runner to cache or restore.
     # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
     # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    # Cache cypress binary to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # To avoid snowballing Cypress binary cache we use the exact key and not the restore keys.
     - name: Cache Cypress Binary
       id: cache-cypress-binary
-      if: (github.ref_name != 'main') && (github.ref_name != 'master')
       uses: actions/cache@v3
       with:
         path: '~/.cache/Cypress'
         key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
 
-    # Install dependencies when the cache has not been retrieved
-    # if: steps.cache-node-modules.outputs.cache-hit != 'true'
+    # Install dependencies
+    # The --cached flag with 'yarn add' is used  to use cached downloads (in the cache directory mentioned above) 
+    # during installation whenever possible instead of downloading them.
     - name: Install dependencies
       id: install
       run: yarn add --cached
@@ -193,7 +197,7 @@ jobs:
         REACT_APP_SHOW_NOTIFICATIONS: ${{ secrets.show-notifications }}
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
         REACT_APP_STRIPE_PUBLISHABLE_KEY: ${{ secrets.stripe-publishable-key }}
-      # Run a set of commands using the runners shell to perform install and build
+      # Run a set of commands using the runners shell to perform build
       run: yarn run build
 
     # Cache build to share it between jobs
@@ -226,20 +230,25 @@ jobs:
       with:
         node-version: '16'
         check-latest: true
-        cache: 'yarn'
 
-    # # Cache dependencies to speed up workflow
-    # # path: The file path on the runner to cache or restore.
-    # # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
-    # # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
-    # - name: Cache dependencies
-    #   id: cache-node-modules
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: '**/node_modules'
-    #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #         ${{ runner.os }}-modules-
+    # Get the yarn cache path.
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: |
+        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+    # Cache dependencies to speed up workflow. Only for development branches
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     # Cache cypress binary to speed up workflow
     # path: The file path on the runner to cache or restore.
@@ -252,8 +261,7 @@ jobs:
         path: '~/.cache/Cypress'
         key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
 
-    # Install dependencies when the cache has not been retrieved
-    # if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
+    # Install dependencies
     - name: Install dependencies
       id: install
       run: yarn add --cached
@@ -304,9 +312,9 @@ jobs:
 
   # Deploy to development environment
   deploy: 
-    needs: test
     name: Deploy
-    if: (github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')
+    needs: [build, test]
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -303,7 +303,7 @@ jobs:
   deploy: 
     needs: test
     name: Deploy
-    if: (github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')
+    if: (github.ref_name == 'main') || (github.ref_name == 'master')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -64,40 +64,28 @@ env:
 
 # This workflow is made up of three jobs that run sequentially, called test, build and deploy
 jobs:
-  test:
-    name: Test
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    # This step runs a single command to execute unitary testing
-    - name: Test job
-      run: |
-        echo "This is the test job"
-
   # Build and sync with S3
   build:
-    needs: test
     name: Build
     runs-on: ubuntu-latest
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true
+
+    # Install dependencies when the cache has not been retrieved
+    - name: Install dependencies
+      id: install
+      run: yarn install
 
     - name: Yarn build dev
       id: build-image
@@ -120,8 +108,39 @@ jobs:
         REACT_APP_STRIPE_PUBLISHABLE_KEY: ${{ secrets.stripe-publishable-key }}
       # Run a set of commands using the runners shell to perform install and build
       run: |
-        yarn install
         yarn run build
+
+    # Cache build to share it between jobs
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the run_id to create a new build for every run.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ github.ref_name }}-
+          ${{ runner.os }}-build-
+
+  # Deploy to development environment
+  deploy: 
+    needs: test
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    # Cache build to re-use it from previous jobs
+    - name: Cache build
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ github.ref_name }}-
+          ${{ runner.os }}-build-
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials
@@ -142,21 +161,6 @@ jobs:
       # --acl public-read makes files publicly readable 
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
-
-  # Deploy to development environment
-  deploy: 
-    needs: build
-    name: Deploy
-    runs-on: ubuntu-latest
-
-    steps:
-    # Configure AWS credential and region environment variables for use in next steps
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.aws-access-key-id }}
-        aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-        aws-region: ${{ secrets.aws-region }}
 
     # Create a new invalidation
     - name: Invalidate cloudfront distribution

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -269,7 +269,7 @@ jobs:
   deploy: 
     name: Deploy
     needs: [build, test]
-    if: ${{ always() && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
+    if: ${{ always() && needs.build.result == 'success' && ((github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -62,7 +62,7 @@ env:
   # Allows to increase Node's max heap size
   NODE_OPTIONS: '--max_old_space_size=8192'
 
-# This workflow is made up of three jobs that run sequentially, called test, build and deploy
+# This workflow is made up of two jobs that run sequentially, called build and deploy
 jobs:
   # Build and sync with S3
   build:
@@ -141,7 +141,7 @@ jobs:
 
   # Deploy to development environment
   deploy: 
-    needs: test
+    needs: build
     name: Deploy
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -56,6 +56,11 @@ on:
       stripe-publishable-key:
         required: false
 
+# Saving computation time by stopping obsolete workflows
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 # Set environment variables that are available to the steps of all jobs in the workflow
 env:
   BUILD_FOLDER: '${{ inputs.build-folder }}'

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -11,6 +11,54 @@ on:
         required: false
         default: 'build'
         type: string
+      graasp-compose-host-test:
+        required: false
+        type: string
+      graasp-authentication-host-test:
+        required: false
+        type: string
+      node-env-test:
+        required: false
+        type: string
+      hidden-item-tag-id-test:
+        required: false
+        type: string
+      public-tag-id-test:
+        required: false
+        type: string
+      next-public-google-analytics-id-test:
+        required: false
+        type: string
+      next-public-published-tag-id-test:
+        required: false
+        type: string
+      next-public-api-host-test:
+        required: false
+        type: string
+      next-public-graasp-perform-host-test:
+        required: false
+        type: string
+      next-public-graasp-authentication-host-test:
+        required: false
+        type: string
+      next-public-node-env-test:
+        required: false
+        type: string
+      graasper-id-test:
+        required: false
+        type: string
+      graasp-domain-test:
+        required: false
+        type: string
+      graasp-app-id-test:
+        required: false
+        type: string
+      mock-api-test:
+        required: false
+        type: string
+      enable-mock-api-test:
+        required: false
+        type: string
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -55,10 +103,12 @@ on:
         required: false
       stripe-publishable-key:
         required: false
+      api-host-test: 
+        required: false
 
 # Saving computation time by stopping obsolete workflows
 concurrency: 
-  group: ${{ github.workflow }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
@@ -140,10 +190,107 @@ jobs:
         path: build
         key: ${{ runner.os }}-build-${{ github.ref_name }}-${{ github.run_id }}
 
+  test:
+    name: Cypress
+    needs: build
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    # Download and cache distribution of the requested Node.js version, and add it to the PATH
+    - name: Setup node
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        check-latest: true
+
+    # Cache dependencies to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-node-modules
+      uses: actions/cache@v3
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-modules-
+
+    # Cache cypress binary to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache Cypress Binary
+      id: cache-cypress-binary
+      uses: actions/cache@v3
+      with:
+        path: '~/.cache/Cypress'
+        key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-cypress-binary-
+
+    # Install dependencies when the cache has not been retrieved
+    - name: Install dependencies
+      id: install
+      if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
+      run: yarn install
+
+    #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
+    - name: Cypress run
+      uses: cypress-io/github-action@v4
+      with:
+        install: false
+        config: baseUrl=http://localhost:3000
+        start: yarn start:ci
+        wait-on: 'http://localhost:3000'
+        wait-on-timeout: 180
+        browser: chrome
+        quiet: true
+      env:
+        REACT_APP_API_HOST: ${{ secrets.api-host-test }}
+        REACT_APP_GRAASP_COMPOSE_HOST: ${{ inputs.graasp-compose-host-test }}
+        REACT_APP_AUTHENTICATION_HOST: ${{ inputs.graasp-authentication-host-test }}
+        REACT_APP_NODE_ENV: ${{ inputs.node-env-test }}
+        REACT_APP_HIDDEN_ITEM_TAG_ID: ${{ inputs.hidden-item-tag-id-test }}
+        REACT_APP_PUBLIC_TAG_ID: ${{ inputs.public-tag-id-test }}
+        NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${{ inputs.next-public-google-analytics-id-test }}
+        NEXT_PUBLIC_PUBLISHED_TAG_ID: ${{ inputs.next-public-published-tag-id-test }}
+        NEXT_PUBLIC_API_HOST: ${{ inputs.next-public-api-host-test }}
+        NEXT_PUBLIC_GRAASP_AUTH_HOST: ${{ inputs.next-public-graasp-authentication-host-test }}
+        NEXT_PUBLIC_GRAASP_PERFORM_HOST: ${{ inputs.next-public-graasp-perform-host-test }}
+        GRAASPER_ID: ${{ inputs.graasper-id-test }}
+        NEXT_PUBLIC_NODE_ENV: ${{ inputs.next-public-node-env-test }}
+        REACT_APP_GRAASP_DOMAIN: ${{ inputs.graasp-domain-test }}
+        REACT_APP_GRAASP_APP_ID: ${{ inputs.graasp-app-id-test }}
+        REACT_APP_MOCK_API: ${{ inputs.mock-api-test }}
+        NODE_ENV: ${{ inputs.node-env-test}}
+        REACT_APP_ENABLE_MOCK_API: ${{ inputs.enable-mock-api-test }}
+
+    # after the test run completes
+    # store any screenshots
+    # NOTE: screenshots will be generated only if E2E test failed
+    # thus we store screenshots only on failures
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: cypress/screenshots
+
+    - name: coverage report
+      run: npx nyc report --reporter=text-summary
+
   # Deploy to development environment
   deploy: 
-    needs: build
+    needs: test
     name: Deploy
+    if: (github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -59,6 +59,10 @@ on:
       enable-mock-api-test:
         required: false
         type: string
+      test-execution:
+        required: true
+        type: boolean
+        default: true
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables
@@ -136,20 +140,21 @@ jobs:
       with:
         node-version: '16'
         check-latest: true
+        cache: 'yarn'
 
-    # Cache dependencies to speed up workflow. Only for development branches
-    # path: The file path on the runner to cache or restore.
-    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
-    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
-    - name: Cache dependencies
-      id: cache-node-modules
-      if: (github.ref_name != 'main') && (github.ref_name != 'master')
-      uses: actions/cache@v3
-      with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-            ${{ runner.os }}-modules-
+    # # Cache dependencies to speed up workflow. Only for development branches
+    # # path: The file path on the runner to cache or restore.
+    # # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    # - name: Cache dependencies
+    #   id: cache-node-modules
+    #   if: (github.ref_name != 'main') && (github.ref_name != 'master')
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: '**/node_modules'
+    #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+    #     restore-keys: |
+    #         ${{ runner.os }}-modules-
 
     # Cache cypress binary to speed up workflow
     # path: The file path on the runner to cache or restore.
@@ -157,18 +162,17 @@ jobs:
     # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
     - name: Cache Cypress Binary
       id: cache-cypress-binary
+      if: (github.ref_name != 'main') && (github.ref_name != 'master')
       uses: actions/cache@v3
       with:
         path: '~/.cache/Cypress'
         key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-            ${{ runner.os }}-cypress-binary-
 
     # Install dependencies when the cache has not been retrieved
+    # if: steps.cache-node-modules.outputs.cache-hit != 'true'
     - name: Install dependencies
       id: install
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: yarn install
+      run: yarn --prefer-offline
 
     - name: Yarn build dev
       id: build-image
@@ -190,8 +194,7 @@ jobs:
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
         REACT_APP_STRIPE_PUBLISHABLE_KEY: ${{ secrets.stripe-publishable-key }}
       # Run a set of commands using the runners shell to perform install and build
-      run: |
-        yarn run build
+      run: yarn run build
 
     # Cache build to share it between jobs
     # path: The file path on the runner to cache or restore.
@@ -206,6 +209,7 @@ jobs:
   test:
     name: Test
     needs: build
+    if: inputs.test-execution == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -222,19 +226,20 @@ jobs:
       with:
         node-version: '16'
         check-latest: true
+        cache: 'yarn'
 
-    # Cache dependencies to speed up workflow
-    # path: The file path on the runner to cache or restore.
-    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
-    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
-    - name: Cache dependencies
-      id: cache-node-modules
-      uses: actions/cache@v3
-      with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-            ${{ runner.os }}-modules-
+    # # Cache dependencies to speed up workflow
+    # # path: The file path on the runner to cache or restore.
+    # # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    # - name: Cache dependencies
+    #   id: cache-node-modules
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: '**/node_modules'
+    #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+    #     restore-keys: |
+    #         ${{ runner.os }}-modules-
 
     # Cache cypress binary to speed up workflow
     # path: The file path on the runner to cache or restore.
@@ -246,14 +251,12 @@ jobs:
       with:
         path: '~/.cache/Cypress'
         key: ${{ runner.os }}-cypress-binary-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-            ${{ runner.os }}-cypress-binary-
 
     # Install dependencies when the cache has not been retrieved
+    # if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
     - name: Install dependencies
       id: install
-      if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
-      run: yarn install
+      run: yarn --prefer-offline
 
     #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
     - name: Cypress run
@@ -303,7 +306,7 @@ jobs:
   deploy: 
     needs: test
     name: Deploy
-    if: (github.ref_name == 'main') || (github.ref_name == 'master')
+    if: (github.event_name == 'workflow_dispatch') || (github.ref_name == 'main') || (github.ref_name == 'master')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -172,7 +172,7 @@ jobs:
     # if: steps.cache-node-modules.outputs.cache-hit != 'true'
     - name: Install dependencies
       id: install
-      run: yarn --prefer-offline
+      run: yarn --cached
 
     - name: Yarn build dev
       id: build-image
@@ -256,7 +256,7 @@ jobs:
     # if: (steps.cache-node-modules.outputs.cache-hit != 'true') || (steps.cache-cypress-binary.outputs.cache-hit != 'true')
     - name: Install dependencies
       id: install
-      run: yarn --prefer-offline
+      run: yarn --cached
 
     #  use the Cypress GitHub Action to run Cypress tests within the chrome browser
     - name: Cypress run

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -181,7 +181,7 @@ jobs:
     name: Test
     needs: build
     # This job is executed only when the user manually selects this option. If not, the code will be deployed without testing.
-    if: inputs.test-execution == true
+    if: ${{ (inputs.test-execution == true) ||  (github.event_name == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
       test-execution:
-        required: true
+        required: false
         type: boolean
         default: true
     # Define secrets which can be passed from the caller workflow

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -11,52 +11,19 @@ on:
         required: false
         default: 'build'
         type: string
-      graasp-compose-host-test:
-        required: false
-        type: string
       graasp-authentication-host-test:
         required: false
         type: string
-      node-env-test:
+      graasp-compose-host-test:
         required: false
         type: string
       hidden-item-tag-id-test:
         required: false
         type: string
+      node-env-test:
+        required: false
+        type: string
       public-tag-id-test:
-        required: false
-        type: string
-      next-public-google-analytics-id-test:
-        required: false
-        type: string
-      next-public-published-tag-id-test:
-        required: false
-        type: string
-      next-public-api-host-test:
-        required: false
-        type: string
-      next-public-graasp-perform-host-test:
-        required: false
-        type: string
-      next-public-graasp-authentication-host-test:
-        required: false
-        type: string
-      next-public-node-env-test:
-        required: false
-        type: string
-      graasper-id-test:
-        required: false
-        type: string
-      graasp-domain-test:
-        required: false
-        type: string
-      graasp-app-id-test:
-        required: false
-        type: string
-      mock-api-test:
-        required: false
-        type: string
-      enable-mock-api-test:
         required: false
         type: string
       test-execution:
@@ -279,23 +246,11 @@ jobs:
         quiet: true
       env:
         REACT_APP_API_HOST: ${{ secrets.api-host-test }}
-        REACT_APP_GRAASP_COMPOSE_HOST: ${{ inputs.graasp-compose-host-test }}
         REACT_APP_AUTHENTICATION_HOST: ${{ inputs.graasp-authentication-host-test }}
-        REACT_APP_NODE_ENV: ${{ inputs.node-env-test }}
+        REACT_APP_GRAASP_COMPOSE_HOST: ${{ inputs.graasp-compose-host-test }}
         REACT_APP_HIDDEN_ITEM_TAG_ID: ${{ inputs.hidden-item-tag-id-test }}
+        REACT_APP_NODE_ENV: ${{ inputs.node-env-test }}
         REACT_APP_PUBLIC_TAG_ID: ${{ inputs.public-tag-id-test }}
-        NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${{ inputs.next-public-google-analytics-id-test }}
-        NEXT_PUBLIC_PUBLISHED_TAG_ID: ${{ inputs.next-public-published-tag-id-test }}
-        NEXT_PUBLIC_API_HOST: ${{ inputs.next-public-api-host-test }}
-        NEXT_PUBLIC_GRAASP_AUTH_HOST: ${{ inputs.next-public-graasp-authentication-host-test }}
-        NEXT_PUBLIC_GRAASP_PERFORM_HOST: ${{ inputs.next-public-graasp-perform-host-test }}
-        GRAASPER_ID: ${{ inputs.graasper-id-test }}
-        NEXT_PUBLIC_NODE_ENV: ${{ inputs.next-public-node-env-test }}
-        REACT_APP_GRAASP_DOMAIN: ${{ inputs.graasp-domain-test }}
-        REACT_APP_GRAASP_APP_ID: ${{ inputs.graasp-app-id-test }}
-        REACT_APP_MOCK_API: ${{ inputs.mock-api-test }}
-        NODE_ENV: ${{ inputs.node-env-test}}
-        REACT_APP_ENABLE_MOCK_API: ${{ inputs.enable-mock-api-test }}
 
     # after the test run completes
     # store any screenshots

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -82,9 +82,24 @@ jobs:
         node-version: '16'
         check-latest: true
 
+    # Cache dependencies to speed up workflow
+    # path: The file path on the runner to cache or restore.
+    # key: Create cache key using the hashFiles function to create a new cache when dependencies change.
+    # restore-keys: An ordered list of alternative keys to use for finding the cache if no cache hit occurred for key
+    - name: Cache dependencies
+      id: cache-node-modules
+      uses: actions/cache@v3
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.os }}-modules-${{ github.ref_name }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-modules-${{ github.ref_name }}-
+            ${{ runner.os }}-modules-
+
     # Install dependencies when the cache has not been retrieved
     - name: Install dependencies
       id: install
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: yarn install
 
     - name: Yarn build dev

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -28,8 +28,8 @@ on:
         type: string
       test-execution:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
     # Define secrets which can be passed from the caller workflow
     secrets:
       # AWS credentials and variables

--- a/caller-workflow-templates/cintegration-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-backend-caller.yml
@@ -8,8 +8,14 @@ on:
       - main
       - master
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      test-execution:
+        type: boolean
+        default: true
+        description: 'Execute test job (Default: yes)'
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
@@ -34,6 +40,7 @@ jobs:
       subscriptions-plugin: true
       token-based-auth: true
       websockets-plugin: true
+      test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:
@@ -95,3 +102,7 @@ jobs:
       stripe-secret-key:
       stripe-default-plan-price-id:
       thumbnails-path-prefix:
+      mock-secure-session-secret-key:
+      mock-jwt-secret:
+      mock-refresh-token-jwt-secret:
+      mock-auth-token-jwt-secret:

--- a/caller-workflow-templates/cintegration-ecs-backend-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-backend-caller.yml
@@ -3,10 +3,7 @@ name: Deploy to development environment
 # Controls when the action will run
 on:
   # Triggers the workflow on push events only for the main branch
-  push:
-    branches:
-      - main
-      - master
+  push
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:

--- a/caller-workflow-templates/cintegration-ecs-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-caller.yml
@@ -3,13 +3,16 @@ name: Deploy to development environment
 # Controls when the action will run
 on:
   # Triggers the workflow on push events only for the main branch
-  push:
-    branches:
-      - main
-      - master
+  push
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      test-execution:
+        type: boolean
+        default: true
+        description: 'Execute test job (Default: yes)'
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
@@ -21,6 +24,7 @@ jobs:
     # Replace input ecs-task-definition with template file. Format: '.aws/<name>-dev.json'
     with:
       ecs-task-definition:
+      test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:

--- a/caller-workflow-templates/cintegration-ecs-explorer-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-explorer-caller.yml
@@ -3,10 +3,7 @@ name: Deploy to development environment
 # Controls when the action will run
 on:
   # Triggers the workflow on push events only for the main branch
-  push:
-    branches:
-      - main
-      - master
+  push
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:

--- a/caller-workflow-templates/cintegration-ecs-explorer-caller.yml
+++ b/caller-workflow-templates/cintegration-ecs-explorer-caller.yml
@@ -10,6 +10,12 @@ on:
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      test-execution:
+        type: boolean
+        default: true
+        description: 'Execute test job (Default: yes)'
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
@@ -21,6 +27,15 @@ jobs:
     # Replace input ecs-task-definition with template file. Format: '.aws/<name>-dev.json'
     with:
       ecs-task-definition:
+      # Test values
+      graasper-id-test:
+      next-public-api-host-test:
+      next-public-graasp-authentication-host-test:
+      next-public-graasp-perform-host-test:
+      next-public-google-analytics-id-test:
+      next-public-node-env-test:
+      next-public-published-tag-id-test:
+      test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       aws-access-key-id:

--- a/caller-workflow-templates/cintegration-s3-apps-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-apps-caller.yml
@@ -3,10 +3,7 @@ name: Deploy to development environment
 # Controls when the action will run
 on:
   # Triggers the workflow on push events only for the main branch
-  push:
-    branches:
-      - main
-      - master
+  push
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:

--- a/caller-workflow-templates/cintegration-s3-apps-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-apps-caller.yml
@@ -10,6 +10,12 @@ on:
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      test-execution:
+        type: boolean
+        default: true
+        description: 'Execute test job (Default: yes)'
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
@@ -23,6 +29,14 @@ jobs:
     with:
       build-folder: 'build'
       version: 'latest'
+      # Test values
+      api-host-test:
+      enable-mock-api-test:
+      graasp-app-id-test:
+      graasp-domain-test:
+      mock-api-test:
+      node-env-test:
+      test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       app-id:

--- a/caller-workflow-templates/cintegration-s3-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-caller.yml
@@ -29,20 +29,9 @@ jobs:
     with:
       build-folder: 'build'
       # Test values
-      enable-mock-api-test:
-      graasper-id-test:
-      graasp-app-id-test:
       graasp-authentication-host-test:
       graasp-compose-host-test:
-      graasp-domain-test:
       hidden-item-tag-id-test:
-      mock-api-test:
-      next-public-api-host-test:
-      next-public-google-analytics-id-test:
-      next-public-graasp-perform-host-test:
-      next-public-graasp-authentication-host-test:
-      next-public-node-env-test:
-      next-public-published-tag-id-test:
       node-env-test: 
       public-tag-id-test:
       test-execution: ${{ inputs.test-execution }}

--- a/caller-workflow-templates/cintegration-s3-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-caller.yml
@@ -28,10 +28,28 @@ jobs:
     # Replace input build-folder if needed
     with:
       build-folder: 'build'
+      # Test values
+      enable-mock-api-test:
+      graasper-id-test:
+      graasp-app-id-test:
+      graasp-authentication-host-test:
+      graasp-compose-host-test:
+      graasp-domain-test:
+      hidden-item-tag-id-test:
+      mock-api-test:
+      next-public-api-host-test:
+      next-public-google-analytics-id-test:
+      next-public-graasp-perform-host-test:
+      next-public-graasp-authentication-host-test:
+      next-public-node-env-test:
+      next-public-published-tag-id-test:
+      node-env-test: 
+      public-tag-id-test:
       test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       api-host:
+      api-host-test:
       authentication-host:
       aws-access-key-id:
       aws-region:

--- a/caller-workflow-templates/cintegration-s3-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-caller.yml
@@ -3,10 +3,7 @@ name: Deploy to development environment
 # Control when the action will run
 on:
   # Triggers the workflow on push events only for the main branch
-  push:
-    branches:
-      - main
-      - master
+  push
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:

--- a/caller-workflow-templates/cintegration-s3-caller.yml
+++ b/caller-workflow-templates/cintegration-s3-caller.yml
@@ -10,6 +10,12 @@ on:
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      test-execution:
+        type: boolean
+        default: true
+        description: 'Execute test job (Default: yes)'
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
@@ -22,6 +28,7 @@ jobs:
     # Replace input build-folder if needed
     with:
       build-folder: 'build'
+      test-execution: ${{ inputs.test-execution }}
     # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
     secrets:
       api-host:


### PR DESCRIPTION
This PR contains:
- removed the unused **test** job inside the `cdelivery-*.yml` workflows. We now perform the integration test job in the Graasp Deploy workflow
- `cintegration-ecs-explorer.yml`: include test job that matches the current `cypress.yml ` workflow inside the library repo. 
-  `cintegration-s3-apps.yml`: include test job that matches the current `cypress.yml ` workflow inside apps repos. Add cache to build and deploy jobs to improve speed. 
- `cintegration-s3.yml`: include test job that matches the current `cypress.yml ` workflow inside s3 repos. Add cache to build and deploy jobs to improve speed. 
- adapt all the `*-caller.yml` workflows to improve the changes made