### PR TITLE
27/update node version

### DIFF
--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     # Define inputs which can be passed from the caller workflow
     inputs:
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -48,7 +48,7 @@ on:
       save-actions:
         required: true
         type: string
-      subscriptions-plugin: 
+      subscriptions-plugin:
         required: true
         type: string
       token-based-auth:
@@ -65,7 +65,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -184,7 +184,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name-graasp }}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -206,7 +206,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -315,7 +315,7 @@ jobs:
             TOKEN_BASED_AUTH=${{ inputs.token-based-auth }}
             WEBSOCKETS_PLUGIN=${{ inputs.websockets-plugin }}
 
-    # Insert a second container image URI into previously created Amazon ECS task definition JSON file. 
+    # Insert a second container image URI into previously created Amazon ECS task definition JSON file.
     - name: Modify Amazon ECS task definition with second container
       id: task-def-2
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -326,7 +326,7 @@ jobs:
           environment-variables: |
             NODE_ENV=${{ inputs.node-env-iframely }}
 
-    # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
+    # Insert a third container image URI into previously created Amazon ECS task definition JSON file.
     - name: Modify Amazon ECS task definition with third container
       id: task-def-3
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -342,7 +342,7 @@ jobs:
           task-definition: ${{ steps.task-def-3.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true
 
   test:
     name: Test
@@ -352,7 +352,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 

--- a/.github/workflows/cdelivery-ecs-explorer.yml
+++ b/.github/workflows/cdelivery-ecs-explorer.yml
@@ -13,7 +13,7 @@ on:
       app-version:
         required: true
         type: string
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -29,7 +29,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -40,11 +40,11 @@ on:
       container-name-explorer:
         required: true
       # Environment variables
-      next-public-api-host: 
+      next-public-api-host:
         required: true
       next-public-google-analytics-id:
         required: true
-      next-public-graasp-auth-host: 
+      next-public-graasp-auth-host:
         required: true
       next-public-graasp-builder-host:
         required: true
@@ -62,7 +62,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   APP_NAME: ${{ inputs.app-name }}
   APP_VERSION: ${{ inputs.app-version }}
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
@@ -79,14 +79,14 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -153,7 +153,7 @@ jobs:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true
 
   test:
     name: Test
@@ -163,7 +163,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 

--- a/.github/workflows/cdelivery-ecs.yml
+++ b/.github/workflows/cdelivery-ecs.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     # Define inputs which can be passed from the caller workflow
     inputs:
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -22,7 +22,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -37,7 +37,7 @@ on:
       #   required: true or false
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name }}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -52,21 +52,21 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
-      
+
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-    
+
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials
       id: configure-aws
@@ -104,11 +104,11 @@ jobs:
           container-name: ${{ secrets.container-name }}
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           # Uncomment next lines to set environment variables here.
-          # Follow the specified format. 
+          # Follow the specified format.
           # environment-variables: |
           #   ENV_VARIABLE=${{ secrets.env-variable-name }}
 
-    # Uncomment and replicate the following section for every container you want to add to your ECS deployment. 
+    # Uncomment and replicate the following section for every container you want to add to your ECS deployment.
     # # Modify Amazon ECS task definition with second container
     # - name: Modify Amazon ECS task definition
     #   id: task-def-2
@@ -118,7 +118,7 @@ jobs:
     #       container-name: ${{ secrets.container-name-iframely }}
     #       image: ${{ secrets.container-image-iframely}}
     #       # Uncomment next lines to set environment variables here.
-    #       # Follow the specified format. 
+    #       # Follow the specified format.
     #       # environment-variables: |
     #       #   ENV_VARIABLE_2=${{ secrets.env-variable-name-2 }}
 
@@ -129,7 +129,7 @@ jobs:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true
 
   test:
     name: Test
@@ -139,7 +139,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 

--- a/.github/workflows/cdelivery-s3-apps.yml
+++ b/.github/workflows/cdelivery-s3-apps.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -74,7 +74,7 @@ jobs:
     - name: Yarn build staging version
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         REACT_APP_GRAASP_DOMAIN: ${{ secrets.graasp-domain }}
         REACT_APP_GRAASP_APP_ID: ${{ secrets.app-id }}
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
@@ -100,7 +100,7 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}/${{ secrets.app-id }}/${{env.VERSION}}/'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 
@@ -117,7 +117,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 

--- a/.github/workflows/cdelivery-s3-apps.yml
+++ b/.github/workflows/cdelivery-s3-apps.yml
@@ -66,7 +66,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/cdelivery-s3.yml
+++ b/.github/workflows/cdelivery-s3.yml
@@ -85,7 +85,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/cdelivery-s3.yml
+++ b/.github/workflows/cdelivery-s3.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -93,7 +93,7 @@ jobs:
     - name: Yarn build staging version
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         PORT: ${{ secrets.port }}
         REACT_APP_API_HOST: ${{ secrets.api-host }}
         REACT_APP_AUTHENTICATION_HOST: ${{ secrets.authentication-host }}
@@ -130,7 +130,7 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 
@@ -138,7 +138,7 @@ jobs:
     - name: Invalidate cloudfront distribution
       id: invalidate-cloudfront
       run: aws cloudfront create-invalidation --distribution-id ${{ secrets.cloudfront-distribution-id }} --paths "/*"
-    
+
   test:
     name: Test
     needs: build-deploy
@@ -147,7 +147,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 

--- a/.github/workflows/cdeployment-ecs-backend.yml
+++ b/.github/workflows/cdeployment-ecs-backend.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     # Define inputs which can be passed from the caller workflow
     inputs:
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -48,7 +48,7 @@ on:
       save-actions:
         required: true
         type: string
-      subscriptions-plugin: 
+      subscriptions-plugin:
         required: true
         type: string
       token-based-auth:
@@ -65,7 +65,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -184,7 +184,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name-graasp }}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -206,7 +206,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -315,7 +315,7 @@ jobs:
             TOKEN_BASED_AUTH=${{ inputs.token-based-auth }}
             WEBSOCKETS_PLUGIN=${{ inputs.websockets-plugin }}
 
-    # Insert a second container image URI into previously created Amazon ECS task definition JSON file. 
+    # Insert a second container image URI into previously created Amazon ECS task definition JSON file.
     - name: Modify Amazon ECS task definition with second container
       id: task-def-2
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -326,7 +326,7 @@ jobs:
           environment-variables: |
             NODE_ENV=${{ inputs.node-env-iframely }}
 
-    # Insert a third container image URI into previously created Amazon ECS task definition JSON file. 
+    # Insert a third container image URI into previously created Amazon ECS task definition JSON file.
     - name: Modify Amazon ECS task definition with third container
       id: task-def-3
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -342,4 +342,4 @@ jobs:
           task-definition: ${{ steps.task-def-3.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true

--- a/.github/workflows/cdeployment-ecs-explorer.yml
+++ b/.github/workflows/cdeployment-ecs-explorer.yml
@@ -13,7 +13,7 @@ on:
       app-version:
         required: true
         type: string
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -29,7 +29,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -40,11 +40,11 @@ on:
       container-name-explorer:
         required: true
       # Environment variables
-      next-public-api-host: 
+      next-public-api-host:
         required: true
       next-public-google-analytics-id:
         required: true
-      next-public-graasp-auth-host: 
+      next-public-graasp-auth-host:
         required: true
       next-public-graasp-builder-host:
         required: true
@@ -62,7 +62,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   APP_NAME: ${{ inputs.app-name }}
   APP_VERSION: ${{ inputs.app-version }}
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
@@ -79,14 +79,14 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -153,4 +153,4 @@ jobs:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true

--- a/.github/workflows/cdeployment-ecs.yml
+++ b/.github/workflows/cdeployment-ecs.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     # Define inputs which can be passed from the caller workflow
     inputs:
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -22,7 +22,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -37,7 +37,7 @@ on:
       #   required: true or false
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name}}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -52,14 +52,14 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -105,11 +105,11 @@ jobs:
           container-name: ${{ secrets.container-name }}
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           # Uncomment next lines to set environment variables here.
-          # Follow the specified format. 
+          # Follow the specified format.
           # environment-variables: |
           #   ENV_VARIABLE=${{ secrets.env-variable-name }}
 
-    # Uncomment and replicate the following section for every container you want to add to your ECS deployment. 
+    # Uncomment and replicate the following section for every container you want to add to your ECS deployment.
     # # Modify Amazon ECS task definition with second container
     # - name: Modify Amazon ECS task definition
     #   id: task-def-2
@@ -119,7 +119,7 @@ jobs:
     #       container-name: ${{ secrets.container-name-iframely }}
     #       image: ${{ secrets.container-image-iframely}}
     #       # Uncomment next lines to set environment variables here.
-    #       # Follow the specified format. 
+    #       # Follow the specified format.
     #       # environment-variables: |
     #       #   ENV_VARIABLE_2=${{ secrets.env-variable-name-2 }}
 
@@ -130,4 +130,4 @@ jobs:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ecs-service }}
           cluster: ${{ secrets.ecs-cluster }}
-          wait-for-service-stability: true       
+          wait-for-service-stability: true

--- a/.github/workflows/cdeployment-s3-apps.yml
+++ b/.github/workflows/cdeployment-s3-apps.yml
@@ -66,7 +66,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/cdeployment-s3-apps.yml
+++ b/.github/workflows/cdeployment-s3-apps.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -74,7 +74,7 @@ jobs:
     - name: Yarn build production version
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         REACT_APP_GRAASP_DOMAIN: ${{ secrets.graasp-domain }}
         REACT_APP_GRAASP_APP_ID: ${{ secrets.app-id }}
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
@@ -100,7 +100,7 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}/${{ secrets.app-id }}/${{env.VERSION}}/'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 

--- a/.github/workflows/cdeployment-s3.yml
+++ b/.github/workflows/cdeployment-s3.yml
@@ -84,7 +84,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/cdeployment-s3.yml
+++ b/.github/workflows/cdeployment-s3.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
 
@@ -92,7 +92,7 @@ jobs:
     - name: Yarn build production version
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         PORT: ${{ secrets.port }}
         REACT_APP_API_HOST: ${{ secrets.api-host }}
         REACT_APP_AUTHENTICATION_HOST: ${{ secrets.authentication-host }}
@@ -129,7 +129,7 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     # Define inputs which can be passed from the caller workflow
     inputs:
-      # ecs-task-definition: path to task definition json template. 
+      # ecs-task-definition: path to task definition json template.
       ecs-task-definition:
         required: true
         type: string
@@ -44,7 +44,7 @@ on:
       save-actions:
         required: true
         type: string
-      subscriptions-plugin: 
+      subscriptions-plugin:
         required: true
         type: string
       token-based-auth:
@@ -180,7 +180,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name-graasp }}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -198,7 +198,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # This step runs a single command to execute unitary testing
     - name: Test job
@@ -211,13 +211,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
@@ -237,8 +237,8 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr-build
       uses: aws-actions/amazon-ecr-login@v1
-    
-    # Build and tag the docker image 
+
+    # Build and tag the docker image
     - name: Build, tag and push image to AWS ECR
       id: build-image
       env:
@@ -249,7 +249,7 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
   # Deploy to dev environment
-  deploy: 
+  deploy:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest
@@ -257,7 +257,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS credentials

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -25,7 +25,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -36,11 +36,11 @@ on:
       container-name-explorer:
         required: true
       # Environment variables
-      next-public-api-host: 
+      next-public-api-host:
         required: true
       next-public-google-analytics-id:
         required: true
-      next-public-graasp-auth-host: 
+      next-public-graasp-auth-host:
         required: true
       next-public-graasp-builder-host:
         required: true
@@ -58,7 +58,7 @@ on:
         required: true
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   APP_NAME: ${{ inputs.app-name }}
   APP_VERSION: ${{ inputs.app-version }}
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
@@ -78,7 +78,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # This step runs a single command to execute unitary testing
     - name: Test job
@@ -91,14 +91,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
-    
+      uses: actions/checkout@v3
+
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
@@ -118,7 +118,7 @@ jobs:
       id: login-ecr-build
       uses: aws-actions/amazon-ecr-login@v1
 
-    # Build and tag the docker image 
+    # Build and tag the docker image
     - name: Build, tag and push image to AWS ECR
       id: build-image
       env:
@@ -129,7 +129,7 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
   # Deploy to dev environment
-  deploy: 
+  deploy:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS credentials

--- a/.github/workflows/cintegration-ecs.yml
+++ b/.github/workflows/cintegration-ecs.yml
@@ -18,7 +18,7 @@ on:
       aws-secret-access-key:
         required: true
       aws-region:
-        required: true           
+        required: true
       ecs-cluster:
         required: true
       ecs-service:
@@ -33,7 +33,7 @@ on:
       #   required: true or false
 
 # Set environment variables that are available to the steps of all jobs in the workflow
-env:        
+env:
   ECS_TASK_DEFINITION: ${{ inputs.ecs-task-definition }}
   CONTAINER_NAME: ${{ secrets.container-name }}
   ECR_REPOSITORY: ${{ secrets.ecr-repository }}
@@ -51,7 +51,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # This step runs a single command to execute unitary testing
     - name: Test job
@@ -64,14 +64,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     # Define job output that is available to all downstream jobs that depend on this job
-    outputs: 
+    outputs:
       tag: ${{ steps.tag-number.outputs.tag }}
 
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
-    
+      uses: actions/checkout@v3
+
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
@@ -91,7 +91,7 @@ jobs:
       id: login-ecr-build
       uses: aws-actions/amazon-ecr-login@v1
 
-    # Build and tag the docker image 
+    # Build and tag the docker image
     - name: Build, tag and push image to AWS ECR
       id: build-image
       env:
@@ -102,7 +102,7 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
   # Deploy to dev environment
-  deploy: 
+  deploy:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS credentials
@@ -138,11 +138,11 @@ jobs:
           container-name: ${{ secrets.container-name }}
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           # Uncomment next lines to set environment variables here.
-          # Follow the specified format. 
+          # Follow the specified format.
           # environment-variables: |
           #   ENV_VARIABLE=${{ secrets.env-variable-name }}
 
-    # Uncomment and replicate the following section for every container you want to add to your ECS deployment. 
+    # Uncomment and replicate the following section for every container you want to add to your ECS deployment.
     # # Modify Amazon ECS task definition with second container
     # - name: Modify Amazon ECS task definition
     #   id: task-def-2
@@ -152,7 +152,7 @@ jobs:
     #       container-name: ${{ secrets.container-name-iframely }}
     #       image: ${{ secrets.container-image-iframely}}
     #       # Uncomment next lines to set environment variables here.
-    #       # Follow the specified format. 
+    #       # Follow the specified format.
     #       # environment-variables: |
     #       #   ENV_VARIABLE_2=${{ secrets.env-variable-name-2 }}
 

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -76,7 +76,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/cintegration-s3-apps.yml
+++ b/.github/workflows/cintegration-s3-apps.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # This step runs a single command to execute unitary testing
     - name: Test job
@@ -71,7 +71,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
@@ -84,7 +84,7 @@ jobs:
     - name: Yarn build dev
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         REACT_APP_GRAASP_DOMAIN: ${{ secrets.graasp-domain }}
         REACT_APP_GRAASP_APP_ID: ${{ secrets.app-id }}
         REACT_APP_SENTRY_DSN: ${{ secrets.sentry-dsn }}
@@ -110,12 +110,12 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}/${{ secrets.app-id }}/${{env.VERSION}}/'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 
   # Deploy to development environment
-  deploy: 
+  deploy:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow that runs Continuous Integration pipeline for S3 deployments. 
+name: Reusable workflow that runs Continuous Integration pipeline for S3 deployments.
 
 # Control when the action will run
 on:
@@ -73,7 +73,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # This step runs a single command to execute unitary testing
     - name: Test job
@@ -89,7 +89,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
@@ -102,7 +102,7 @@ jobs:
     - name: Yarn build dev
       id: build-image
       # Set environment variables required to perform the build. These are only available to this step
-      env: 
+      env:
         PORT: ${{ secrets.port }}
         REACT_APP_API_HOST: ${{ secrets.api-host }}
         REACT_APP_AUTHENTICATION_HOST: ${{ secrets.authentication-host }}
@@ -139,12 +139,12 @@ jobs:
       env:
         APP_DIR: '${{ secrets.aws-s3-bucket-name }}'
       run: aws s3 sync ${{env.BUILD_FOLDER}} s3://${APP_DIR} --acl public-read --follow-symlinks --delete
-      # --acl public-read makes files publicly readable 
+      # --acl public-read makes files publicly readable
       # --follow-symlinks fixes some weird symbolic link problems that may come up
       # --delete permanently deletes files in the S3 bucket that are not present in the latest version of the repository/build.
 
   # Deploy to development environment
-  deploy: 
+  deploy:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/cintegration-s3.yml
+++ b/.github/workflows/cintegration-s3.yml
@@ -94,7 +94,7 @@ jobs:
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         check-latest: true

--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -1,5 +1,5 @@
-# This workflow takes the latest YYYYMMddhhmm-release-versions.json file inside the release-versions folder 
-# and triggers all the cdeployment workflows in the different repositories. 
+# This workflow takes the latest YYYYMMddhhmm-release-versions.json file inside the release-versions folder
+# and triggers all the cdeployment workflows in the different repositories.
 name: Deploy stack to prod
 
 # Controls when the action will run.
@@ -19,7 +19,7 @@ on:
         # Input does not have to be provided for the workflow to run
         required: false
 
-env:        
+env:
   STACK: ${{ inputs.stack }}
 
 jobs:
@@ -37,9 +37,9 @@ jobs:
 
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    # Set the appropriate job output based on the stack that is being deployed: custom or latest. 
+    # Set the appropriate job output based on the stack that is being deployed: custom or latest.
     - name: Get latest release versions file
       id: latest-release-file
       run: |
@@ -57,10 +57,10 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8 
+        python-version: 3.8
 
     # Run compare.py to get the difference between the newer and the already deployed versions
-    - name: Execute py script 
+    - name: Execute py script
       env:
         LATEST_FILE_NAME_RELEASE: ${{ steps.latest-release-file.outputs.latest }}
       run: |
@@ -87,7 +87,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     # The environment that the job will reference
-    environment: 
+    environment:
       name: production
     strategy:
       # Uses fromJson to parse the output and set a matrix variable.
@@ -120,17 +120,17 @@ jobs:
     needs: [generate-matrix, dispatch]
     runs-on: ubuntu-latest
     # The environment that the job will reference
-    environment: 
+    environment:
       name: production
     env:
       LATEST_FILE_NAME_RELEASE: ${{ needs.generate-matrix.outputs.latest }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Create new production-versions.json file. Use jq to write to stdout and pipe the output to a newly created file.
     - name: Create new production-versions.json file name
-      run: | 
+      run: |
         PRODUCTION_FILE_NAME=$(echo "`date +"%Y%m%d%H%M"`"-production-versions.json)
         echo "PRODUCTION_FILE_NAME=$PRODUCTION_FILE_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -1,5 +1,5 @@
-# This workflow takes the latest YYYYMMddhhmm-staging-versions.json file inside the staging-versions folder 
-# and triggers all the cdelivery workflows in the different repositories. 
+# This workflow takes the latest YYYYMMddhhmm-staging-versions.json file inside the staging-versions folder
+# and triggers all the cdelivery workflows in the different repositories.
 name: Deploy stack to stage
 
 # Controls when the action will run.
@@ -19,7 +19,7 @@ on:
         # Input does not have to be provided for the workflow to run
         required: false
 
-env:        
+env:
   STACK: ${{ inputs.stack }}
 
 jobs:
@@ -37,9 +37,9 @@ jobs:
 
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    # Set the appropriate job output based on the stack that is being deployed: custom or latest. 
+    # Set the appropriate job output based on the stack that is being deployed: custom or latest.
     - name: Get latest staging versions file
       id: latest-staging-file
       run: |
@@ -57,10 +57,10 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8 
+        python-version: 3.8
 
     # Run compare.py to get the difference between the newer and the already deployed versions
-    - name: Execute py script 
+    - name: Execute py script
       env:
         LATEST_FILE_NAME_STAGING: ${{ steps.latest-staging-file.outputs.latest }}
       run: |
@@ -87,7 +87,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     # The environment that the job will reference
-    environment: 
+    environment:
       name: staging
     strategy:
       # Uses fromJson to parse the output and set a matrix variable.
@@ -119,7 +119,7 @@ jobs:
     name: Update deployed staging stack
     needs: [generate-matrix, dispatch]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: staging
     outputs:
       commit-hash: ${{ steps.commit.outputs.commit_hash }}
@@ -127,7 +127,7 @@ jobs:
       LATEST_FILE_NAME_STAGING: ${{ needs.generate-matrix.outputs.latest }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Update current-staging-versions file
       id: update-current-staging-versions-file
@@ -157,19 +157,19 @@ jobs:
     name: Promote stack to release ready
     needs: [generate-matrix, dispatch, update-deployed-stack, test]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: staging
     env:
       LATEST_FILE_NAME_STAGING: ${{ needs.generate-matrix.outputs.latest }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ needs.update-deployed-stack.outputs.commit-hash }}
 
     # Create new staging-versions.json file
     - name: Create new release-versions.json file name
-      run: | 
+      run: |
         RELEASE_FILE_NAME=$(echo "`date +"%Y%m%d%H%M"`"-release-versions.json)
         echo "RELEASE_FILE_NAME=$RELEASE_FILE_NAME" >> $GITHUB_ENV
 
@@ -179,7 +179,7 @@ jobs:
         RELEASE_FILE_NAME: ${{ env.RELEASE_FILE_NAME }}
       run: |
         cd ./staging-versions
-        cp $LATEST_FILE_NAME_STAGING ../release-versions/$RELEASE_FILE_NAME 
+        cp $LATEST_FILE_NAME_STAGING ../release-versions/$RELEASE_FILE_NAME
 
     - name: Keep changes in detached HEAD step
       run: |

--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -1,5 +1,5 @@
-# This workflow creates a new YYYYMMddhhmm-staging-versions.json file inside the staging-versions folder 
-# with the latest tag pushed by the repository that triggered the workflow. 
+# This workflow creates a new YYYYMMddhhmm-staging-versions.json file inside the staging-versions folder
+# with the latest tag pushed by the repository that triggered the workflow.
 name: Update staging stack
 
 # Controls when the action will run
@@ -10,7 +10,7 @@ on:
 
 # This workflow is made up of one job called create
 jobs:
-  # Create a new YYYYMMddhhmm-staging-versions.json file with latest pushed tag. 
+  # Create a new YYYYMMddhhmm-staging-versions.json file with latest pushed tag.
   create:
     name: Create staging-versions.json file
     # The type of runner that the job will run on
@@ -19,7 +19,7 @@ jobs:
     steps:
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Get the latest modified file in the staging-versions working directory.
     - name: Get latest versions file
@@ -35,19 +35,19 @@ jobs:
     - name: Create new staging-versions.json file
       # Set environment variables required to create the file. These are only available to this step
       env:
-        # REPOSITORY: repository that will update current version. 
+        # REPOSITORY: repository that will update current version.
         REPOSITORY: ${{ github.event.client_payload.repository }}
-        # TAG: tag pushed by the repository. 
+        # TAG: tag pushed by the repository.
         TAG: ${{ github.event.client_payload.tag }}
-        # LATEST_FILE_NAME: latest staging-versions.json file created. It will be used as template. 
+        # LATEST_FILE_NAME: latest staging-versions.json file created. It will be used as template.
         LATEST_FILE_NAME: ${{ steps.latest-file.outputs.latest }}
-      run: | 
+      run: |
         FILE_NAME=$(echo "`date +"%Y%m%d%H%M"`"-staging-versions.json)
         echo "FILE_NAME=$FILE_NAME" >> $GITHUB_ENV
         jq --arg tag "$TAG" --arg repository "$REPOSITORY" \
         'if ((.include[] | select(.repository == $repository)) // null) != null then (.include[] | select(.repository == $repository) | .tag) |= $tag else .include += [{"repository": $repository, "tag": $tag}] end' \
         ./staging-versions/$LATEST_FILE_NAME > ./staging-versions/$FILE_NAME
-    
+
     # Detect changed files during a Workflow run and commit and push them back to the GitHub repository
     - name: Commit step
       id: commit
@@ -55,5 +55,3 @@ jobs:
       with:
          # Commit message for the created commit.
         commit_message: ${{ env.FILE_NAME }}
-
-


### PR DESCRIPTION
This PR updates the version of the `actions/checkout` and `actions/setup-node` workflows to use v3 which uses node16 by default.

closes #27 