### PR TITLE
fix: `set-output` deprecation warning

### DIFF
--- a/.github/workflows/cdelivery-ecs-backend.yml
+++ b/.github/workflows/cdelivery-ecs-backend.yml
@@ -213,7 +213,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${{ inputs.tag }}
+      run: echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cdelivery-ecs-explorer.yml
+++ b/.github/workflows/cdelivery-ecs-explorer.yml
@@ -93,7 +93,8 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${{ inputs.tag }}
+      run: echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cdelivery-ecs.yml
+++ b/.github/workflows/cdelivery-ecs.yml
@@ -65,7 +65,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cdeployment-ecs-backend.yml
+++ b/.github/workflows/cdeployment-ecs-backend.yml
@@ -213,7 +213,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${{ inputs.tag }}
+      run: echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cdeployment-ecs-explorer.yml
+++ b/.github/workflows/cdeployment-ecs-explorer.yml
@@ -93,7 +93,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${{ inputs.tag }}
+      run: echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cdeployment-ecs.yml
+++ b/.github/workflows/cdeployment-ecs.yml
@@ -66,7 +66,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cintegration-ecs-backend.yml
+++ b/.github/workflows/cintegration-ecs-backend.yml
@@ -222,7 +222,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cintegration-ecs-explorer.yml
+++ b/.github/workflows/cintegration-ecs-explorer.yml
@@ -102,7 +102,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/cintegration-ecs.yml
+++ b/.github/workflows/cintegration-ecs.yml
@@ -75,7 +75,7 @@ jobs:
     # Set output variable tag with the current checked out ref
     - name: Set Tag Number
       id: tag-number
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     # Configure AWS credential and region environment variables for use in next steps
     - name: Configure AWS Credentials

--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -46,11 +46,11 @@ jobs:
         if [[ "${{ inputs.stack }}" == "" ]]; then
           cd ./release-versions
           LATEST_FILE_NAME_RELEASE=$(ls -Ar | head -n 1)
-          echo ::set-output name=latest::${LATEST_FILE_NAME_RELEASE}
+          echo "latest=${LATEST_FILE_NAME_RELEASE}" >> $GITHUB_OUTPUT
         fi
         if [[ "${{ inputs.stack }}" != "" ]]; then
           LATEST_FILE_NAME_RELEASE=${{ env.STACK }}
-          echo ::set-output name=latest::${LATEST_FILE_NAME_RELEASE}
+          echo "latest=${LATEST_FILE_NAME_RELEASE}" >> $GITHUB_OUTPUT
         fi
 
     # Install the python version needed
@@ -73,7 +73,7 @@ jobs:
         STACK_LENGTH=$(cat diff.json | jq '.include | length')
         if [[ "$STACK_LENGTH" -gt 0 ]]; then
           LATEST_FILE=$(cat diff.json)
-          echo ::set-output name=matrix::${LATEST_FILE//'%'/'%25'}
+          echo "matrix=${LATEST_FILE//'%'/'%25'}" >> $GITHUB_OUTPUT
           echo '### New versions detected! :bookmark:' >> $GITHUB_STEP_SUMMARY
           NEW_STACK=$(cat diff.json | jq -r '.include[] | {repository,tag}| join(" - tag: ")')
           echo $NEW_STACK >> $GITHUB_STEP_SUMMARY
@@ -99,7 +99,7 @@ jobs:
         TAG: ${{matrix.tag}}
       run: |
         JSON=$(jq --null-input --arg tag "$TAG" '{"tag": $tag}')
-        echo ::set-output name=json::${JSON//'%'/'%25'}
+        echo "json=${JSON//'%'/'%25'}" >> $GITHUB_OUTPUT
 
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -46,11 +46,11 @@ jobs:
         if [[ "${{ inputs.stack }}" == "" ]]; then
           cd ./staging-versions
           LATEST_FILE_NAME_STAGING=$(ls -Ar | head -n 1)
-          echo ::set-output name=latest::${LATEST_FILE_NAME_STAGING}
+          echo "latest=${LATEST_FILE_NAME_STAGING}" >> $GITHUB_OUTPUT
         fi
         if [[ "${{ inputs.stack }}" != "" ]]; then
           LATEST_FILE_NAME_STAGING=${{ env.STACK }}
-          echo ::set-output name=latest::${LATEST_FILE_NAME_STAGING}
+          echo "latest=${LATEST_FILE_NAME_STAGING}" >> $GITHUB_OUTPUT
         fi
 
     # Install the python version needed
@@ -73,7 +73,7 @@ jobs:
         STACK_LENGTH=$(cat diff.json | jq '.include | length')
         if [[ "$STACK_LENGTH" -gt 0 ]]; then
           LATEST_FILE=$(cat diff.json)
-          echo ::set-output name=matrix::${LATEST_FILE//'%'/'%25'}
+          echo "matrix=${LATEST_FILE//'%'/'%25'}" >> $GITHUB_OUTPUT
           echo '### New versions detected! :bookmark:' >> $GITHUB_STEP_SUMMARY
           NEW_STACK=$(cat diff.json | jq -r '.include[] | {repository,tag}| join(" - tag: ")')
           echo $NEW_STACK >> $GITHUB_STEP_SUMMARY
@@ -99,7 +99,7 @@ jobs:
         TAG: ${{matrix.tag}}
       run: |
         JSON=$(jq --null-input --arg tag "$TAG" '{"tag": $tag}')
-        echo ::set-output name=json::${JSON//'%'/'%25'}
+        echo "json=${JSON//'%'/'%25'}" >> $GITHUB_OUTPUT
 
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
@@ -143,7 +143,7 @@ jobs:
 
     - name: Set commit hash output
       run: |
-        echo ::set-output name=commit-hash::${{ steps.commit.outputs.commit_hash }}
+        echo "commit-hash=${{ steps.commit.outputs.commit_hash }}" >> $GITHUB_OUTPUT
         echo '### New stack deployed! :rocket:' >> $GITHUB_STEP_SUMMARY
 
   test:

--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         cd ./staging-versions
         LATEST_FILE_NAME=$(ls -Ar | head -n 1)
-        echo ::set-output name=latest::${LATEST_FILE_NAME}
+        echo "latest=${LATEST_FILE_NAME}" >> $GITHUB_OUTPUT
 
     # Create new staging-versions.json file. Use jq to write to stdout and pipe the output to a newly created file.
     # If the file already contains the repository, update the tag value

--- a/.github/workflows/update-staging-version.yml
+++ b/.github/workflows/update-staging-version.yml
@@ -22,7 +22,7 @@ env:
 
 # This workflow is made up of one job called create-release-candidate
 jobs:
-  # Create a json with the repository name and tag and pass it to graasp-deploy repository 
+  # Create a json with the repository name and tag and pass it to graasp-deploy repository
   create-release-candidate:
     name: Create new candidate
     # The type of runner that the job will run on
@@ -40,7 +40,7 @@ jobs:
     - name: Get yarn cache directory
       id: yarn-cache-dir-path
       run: |
-        echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     # Cache dependencies to speed up workflow. Only for development branches
     # path: The file path on the runner to cache or restore.
@@ -56,7 +56,7 @@ jobs:
           ${{ runner.os }}-yarn-
 
     # Install dependencies
-    # The --cached flag with 'yarn add' is used  to use cached downloads (in the cache directory mentioned above) 
+    # The --cached flag with 'yarn add' is used  to use cached downloads (in the cache directory mentioned above)
     # during installation whenever possible instead of downloading them.
     - name: Yarn install
       id: yarn-install
@@ -90,14 +90,14 @@ jobs:
       run: git push --follow-tags
 
     # Get the latest tag and create a json with the repository name and tag
-    # ::set-output name={name}::{value} Sets an output parameter for this step.
+    # "{name}={value}" >> $GITHUB_OUTPUT Sets an output parameter for this step.
     - name: Set tag
       id: set-tag
       run: |
         REPOSITORY=$(echo '${{ github.repository }}')
         TAG=$(git tag)
         JSON=$(jq --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
-        echo ::set-output name=json::${JSON//'%'/'%25'}
+        echo "json=${JSON//'%'/'%25'}" >> $GITHUB_OUTPUT
 
     # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
     - name: Repository Dispatch


### PR DESCRIPTION
This PR addresses the deprecation warning about using `set-output` in workflows.

Fixes #61