### PR TITLE
fix: update setup-python action version

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Install the python version needed
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Install the python version needed
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 


### PR DESCRIPTION
This PR updates the version of `actions/setup-python` to use the latest `v4` which uses node 16 by default.

closes #59 