### PR TITLE
fix: update commit messages to follow conventional commits

### DIFF
--- a/.github/workflows/staging-test.yml
+++ b/.github/workflows/staging-test.yml
@@ -1,6 +1,6 @@
 name: Integration tests in stage
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Allow the workflow to be reusable
   workflow_call:
@@ -27,7 +27,7 @@ jobs:
         echo "DATE=$DATE" >> $GITHUB_ENV
 
     # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-    - name: Git checkout 
+    - name: Git checkout
       uses: actions/checkout@v3
 
     # Download and cache distribution of the requested Node.js version, and add it to the PATH
@@ -65,14 +65,14 @@ jobs:
       if: always()
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: 'Smoke test run ${{ env.DATE }}'
+        commit_message: 'chore(test): Smoke test run ${{ env.DATE }}'
         branch: gh-pages
         file_pattern: newman/*
 
   api-test:
     name: Graasp API Test
     runs-on: ubuntu-latest
-    env:        
+    env:
       PASSWORD: ${{ secrets.STAGING_PASSWORD }}
       EMAIL: ${{ secrets.STAGING_EMAIL }}
       API_HOST: ${{ secrets.REACT_APP_API_HOST_STAGE }}
@@ -84,7 +84,7 @@ jobs:
         DATE=$(echo "`date +"%Y-%m-%d-%H-%M"`")
         echo "DATE=$DATE" >> $GITHUB_ENV
 
-    - name: Git checkout 
+    - name: Git checkout
       uses: actions/checkout@v3
 
     - name: Setup node
@@ -127,6 +127,6 @@ jobs:
       if: always()
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: 'API test run ${{ env.DATE }}'
+        commit_message: 'chore(test): run API tests ${{ env.DATE }}'
         branch: gh-pages
         file_pattern: newman/*

--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -155,7 +155,7 @@ jobs:
       id: commit
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Deploy new stack to production environment
+        commit_message: "chore(deploy): deploy new stack to production environment"
 
     - name: Generate job summary markdown
       run: |

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -139,7 +139,7 @@ jobs:
       id: commit
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Deploy new stack to staging environment
+        commit_message: 'chore(deploy): deploy new stack to staging environment'
 
     - name: Set commit hash output
       run: |
@@ -192,7 +192,7 @@ jobs:
       id: commit
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Promote new stack to release ready
+        commit_message: 'chore: promote new stack to release ready'
 
     - name: Generate job summary markdown
       run: |

--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -54,4 +54,4 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
          # Commit message for the created commit.
-        commit_message: ${{ env.FILE_NAME }}
+        commit_message: 'chore: updated staging stack ${{ env.FILE_NAME }}'


### PR DESCRIPTION
This PR updates the automatic commits to use conventional commits so that they will not trigger a bump in standard version.

Those commits are now marked as `chore` with a scope when it applies.

closes #69 