### PR TITLE
feat: add minor and major tag follow after releasing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
+        id: release
         with:
           release-type: simple
           package-name: graasp-deploy
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false}]'
+      - uses: actions/checkout@v3
+      - name: Tag major and minor versions
+        uses: jacobsvante/tag-major-minor-action
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          major: ${{ steps.release.outputs.major }}
+          minor: ${{ steps.release.outputs.minor }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false}]'
       - uses: actions/checkout@v3
       - name: Tag major and minor versions
-        uses: jacobsvante/tag-major-minor-action
+        uses: jacobsvante/tag-major-minor-action@v0.1
         if: ${{ steps.release.outputs.release_created }}
         with:
           major: ${{ steps.release.outputs.major }}


### PR DESCRIPTION
This PR adds support to make the major `v1` and minor `v1.2` follow the latest release so we can use `v1` in the workflows and always have the latest version.