### PR TITLE
fix(ci): remove indentation from diff.json and following minification

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -73,7 +73,7 @@ jobs:
         STACK_LENGTH=$(cat diff.json | jq '.include | length')
         if [[ "$STACK_LENGTH" -gt 0 ]]; then
           LATEST_FILE=$(cat diff.json)
-          echo "matrix=${LATEST_FILE//'%'/'%25'}" >> $GITHUB_OUTPUT
+          echo "matrix=$LATEST_FILE" >> $GITHUB_OUTPUT
           echo '### New versions detected! :bookmark:' >> $GITHUB_STEP_SUMMARY
           NEW_STACK=$(cat diff.json | jq -r '.include[] | {repository,tag}| join(" - tag: ")')
           echo $NEW_STACK >> $GITHUB_STEP_SUMMARY

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -23,13 +23,13 @@ for new_item in new_file['include']:
                 print('New tag')
                 print(new_item['tag'])
                 output['include'].append(new_item)
-            else: 
+            else:
                 break
 
     if new_item['repository'] not in visited:
         print(f"Found new repository in stack: {new_item['repository']}")
-        output['include'].append(new_item)        
+        output['include'].append(new_item)
 
 # New file
 output_file = open("diff.json", "w")
-json.dump(output, output_file, indent=2)
+json.dump(output, output_file)


### PR DESCRIPTION
This PR is a hot-fix for the failed deploy to prod workflow.

The bug was introduced in #62 when changing from `set-output` to the new convention and using double quotes which disabled the substitution.

Solution was to remove the indentation when generating the file in python.

closes #79 