### PR TITLE
fix: bring back jq with single line output (-c) and remove braces escape

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -98,7 +98,8 @@ jobs:
       env:
         TAG: ${{matrix.tag}}
       run: |
-        echo "json=\{\"tag\": \"$TAG\"\}" >> $GITHUB_OUTPUT
+        JSON=$(jq -c --null-input --arg tag "$TAG" '{"tag": $tag}')
+        echo "json=$JSON" >> $GITHUB_OUTPUT
 
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -98,7 +98,8 @@ jobs:
       env:
         TAG: ${{matrix.tag}}
       run: |
-        echo "json=\{\"tag\": \"$TAG\"\}" >> $GITHUB_OUTPUT
+        JSON=$(jq -c --null-input --arg tag "$TAG" '{"tag": $tag}')
+        echo "json=$JSON" >> $GITHUB_OUTPUT
 
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/update-staging-version.yml
+++ b/.github/workflows/update-staging-version.yml
@@ -96,8 +96,8 @@ jobs:
       run: |
         REPOSITORY=$(echo '${{ github.repository }}')
         TAG=$(git tag)
-        JSON=$(jq --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
-        echo "json=${JSON//'%'/'%25'}" >> $GITHUB_OUTPUT
+        JSON=$(jq -c --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
+        echo "json=$JSON" >> $GITHUB_OUTPUT
 
     # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
     - name: Repository Dispatch


### PR DESCRIPTION
Hopefully last time.
This PR brings back jq with the `-c` argument that formats the output json as a single line.

closes #79 