### PR TITLE
fix(ci): replace REPO_ACCESS_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ matrix.repository }}
         event-type: production-deployment
         client-payload: ${{steps.set-json.outputs.json}}

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ matrix.repository }}
         event-type: staging-deployment
         client-payload: ${{steps.set-json.outputs.json}}


### PR DESCRIPTION
This PR replaces the `REPO_ACCESS_TOKEN` with `GITHUB_TOKEN` to solve `Bad Credentials` issue.

closes #84 