### PR TITLE
chore(fmt): improve formatting of new stack output

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -75,8 +75,9 @@ jobs:
           LATEST_FILE=$(cat diff.json)
           echo "matrix=$LATEST_FILE" >> $GITHUB_OUTPUT
           echo '### New versions detected! :bookmark:' >> $GITHUB_STEP_SUMMARY
-          NEW_STACK=$(cat diff.json | jq -r '.include[] | {repository,tag}| join(" - tag: ")')
-          echo $NEW_STACK >> $GITHUB_STEP_SUMMARY
+          # this line joins the repo - tag values to produce a nice output
+          NEW_STACK=$(cat diff.json | jq -r '[ .include[] | {repository,tag} | join(" - tag: ") ] |  join("  \n")')
+          echo "$NEW_STACK" >> $GITHUB_STEP_SUMMARY
         else
           echo '### No new versions detected! :hankey:' >> $GITHUB_STEP_SUMMARY
           exit 1

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -75,8 +75,9 @@ jobs:
           LATEST_FILE=$(cat diff.json)
           echo "matrix=$LATEST_FILE" >> $GITHUB_OUTPUT
           echo '### New versions detected! :bookmark:' >> $GITHUB_STEP_SUMMARY
-          NEW_STACK=$(cat diff.json | jq -r '.include[] | {repository,tag}| join(" - tag: ")')
-          echo $NEW_STACK >> $GITHUB_STEP_SUMMARY
+          # this line joins the repo - tag values to produce a nice output
+          NEW_STACK=$(cat diff.json | jq -r '[ .include[] | {repository,tag} | join(" - tag: ") ] |  join("  \n")')
+          echo "$NEW_STACK" >> $GITHUB_STEP_SUMMARY
         else
           echo '### No new versions detected! :hankey:' >> $GITHUB_STEP_SUMMARY
           exit 1


### PR DESCRIPTION
This PR improves the formatting of the step summary showing the new stack.

### What's changed ?
- Pairs of repo-tag should now be show one per line (adding double spaces and new line between outputs).
- `echo` also uses double quotes to stay consistant.

closes #88 