### PR TITLE
fix: summary step update staging stack

### DIFF
--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -55,3 +55,8 @@ jobs:
       with:
          # Commit message for the created commit.
         commit_message: 'chore: updated staging stack ${{ env.FILE_NAME }}'
+
+    - name: Summary step
+      run: |
+        LATEST_FILE_LINK="https://github.com/${{ github.repository }}/blob/main/staging-versions/${{ env.FILE_NAME }}"
+        echo "### :postbox: Updated $REPOSITORY to `$TAG`\n\n[Go to generated staging version file]($LATEST_FILE_LINK)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR improves the step summary when updating the staging stack to indicate which repo with which tag was updated.

closes #99 