### PR TITLE
fix: add missing env vars in update-staging-version workflow

### DIFF
--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -57,6 +57,11 @@ jobs:
         commit_message: 'chore: updated staging stack ${{ env.FILE_NAME }}'
 
     - name: Summary step
+      env:
+        # REPOSITORY: repository that will update current version.
+        REPOSITORY: ${{ github.event.client_payload.repository }}
+        # TAG: tag pushed by the repository.
+        TAG: ${{ github.event.client_payload.tag }}
       run: |
         LATEST_FILE_LINK="https://github.com/${{ github.repository }}/blob/main/staging-versions/${{ env.FILE_NAME }}"
-        echo "### :postbox: Updated $REPOSITORY to `$TAG`\n\n[Go to generated staging version file]($LATEST_FILE_LINK)" >> $GITHUB_STEP_SUMMARY
+        echo "### :postbox: Updated $REPOSITORY to `$TAG`  \n[Go to generated staging version file]($LATEST_FILE_LINK)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR fixes a minor display bug and adds the missing env vars in the update-staging-version workflow.

closes #107 