### PR TITLE
fix: checkout latest commits of main branch after suspend in staging

### DIFF
--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -132,6 +132,9 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+      with:
+        # checkout the latest commits of main -> this is where we will commit to
+        ref: main
 
     - name: Update current-staging-versions file
       id: update-current-staging-versions-file


### PR DESCRIPTION
This PR attempts to fix the issue that we need to pull when there are new commits while the trigger staging stack workflow is supended.

closes #110 