### PR TITLE
125 visualize deployements

### DIFF
--- a/.github/workflows/update-staging-stack.yml
+++ b/.github/workflows/update-staging-stack.yml
@@ -47,6 +47,7 @@ jobs:
         jq --arg tag "$TAG" --arg repository "$REPOSITORY" \
         'if ((.include[] | select(.repository == $repository)) // null) != null then (.include[] | select(.repository == $repository) | .tag) |= $tag else .include += [{"repository": $repository, "tag": $tag}] end' \
         ./staging-versions/$LATEST_FILE_NAME > ./staging-versions/$FILE_NAME
+        cat ./staging-versions/$FILE_NAME > ./staging-versions/latest.json
 
     # Detect changed files during a Workflow run and commit and push them back to the GitHub repository
     - name: Commit step

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Deploy Graasp ecosystem in AWS using Github workflows and Github actions.
 
+<a href="/current">View Deployed versions</a>
+
 ## Contents
 
 - [What Graasp Deploy does](#what-graasp-deploy-does)

--- a/current/index.html
+++ b/current/index.html
@@ -16,15 +16,19 @@
       <h1>Currently deployed versions</h1>
       <p>
         This table presents the currently deployed versions on
-        <em>staging</em> and <em>production</em>. When staging has a newer
-        version than produciton, a
-        <span class="badge bg-success">New</span> badge is shown after the
-        repository name.
+        <em>staging</em> and <em>production</em>. When there is a new version
+        that is not yet on staging, a
+        <span class="badge rounded-pill bg-success">New version</span> badge is
+        shown after the repository name. When there is a new version that is not
+        yet on production, the line is highlighted with a
+        <span style="background-color: #d1e7dd; padding: 2px">green color</span>
+        .
       </p>
       <table class="table">
         <thead>
           <tr>
             <th scope="col">Repo</th>
+            <th scope="col">Latest version</th>
             <th scope="col">Staging version</th>
             <th scope="col">Prod version</th>
           </tr>

--- a/current/index.html
+++ b/current/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Current Stacks | Graasp Deploy</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Currently deployed versions</h1>
+      <p>
+        This table presents the currently deployed versions on
+        <em>staging</em> and <em>production</em>. When staging has a newer
+        version than produciton, a
+        <span class="badge bg-success">New</span> badge is shown after the
+        repository name.
+      </p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Repo</th>
+            <th scope="col">Staging version</th>
+            <th scope="col">Prod version</th>
+          </tr>
+        </thead>
+        <tbody id="table-content"></tbody>
+      </table>
+    </div>
+    <script src="main.js"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/current/main.js
+++ b/current/main.js
@@ -2,7 +2,7 @@ const DEPLOYED_VERSIONS = ["staging", "production"];
 const VERSIONS = ["latest", "staging", "production"];
 
 async function loadData() {
-  return await Promise.all([
+  return Promise.all([
     fetch(
       "https://raw.githubusercontent.com/graasp/graasp-deploy/main/staging-versions/latest.json"
     ).then((res) => res.json()),
@@ -83,8 +83,6 @@ async function main() {
   const repoArr = Object.keys(repoData)
     .sort()
     .map((repo) => ({ repo, ...repoData[repo] }));
-
-  console.log(repoArr);
 
   // populate table with versions
   populateTable(repoArr);

--- a/current/main.js
+++ b/current/main.js
@@ -1,0 +1,83 @@
+const VERSIONS = ["staging", "production"];
+
+async function loadData() {
+  return await Promise.all(
+    VERSIONS.map((version) =>
+      fetch(
+        `https://graasp.github.io/graasp-deploy/deployed/current-${version}-versions.json`
+      ).then((res) => res.json())
+    )
+  );
+}
+
+function createVersionCell(row, key) {
+  const node = document.createElement("td");
+  if (!row[key]) {
+    node.className = "table-warning";
+    const content = document.createTextNode(row[key] || "Not deployed");
+    node.appendChild(content);
+  } else {
+    const elem = document.createElement("a");
+    elem.href = `https://github.com/${row.repo}/releases/tag/${row[key]}`;
+    elem.innerHTML = row[key];
+    elem.target = "_blank";
+    node.appendChild(elem);
+  }
+  return node;
+}
+
+function populateTable(data) {
+  var tableElement = document.getElementById("table-content");
+  data.forEach((repoData) => {
+    var tableRow = document.createElement("tr");
+
+    const repoCell = document.createElement("td");
+    const elem = document.createElement("a");
+    elem.className = "text-decoration-none";
+    elem.href = "https://github.com/graasp/graasp/";
+
+    elem.innerHTML = `${repoData.repo} ${
+      repoData.staging !== repoData.production
+        ? '<span class="badge bg-success">New</span>'
+        : ""
+    }`;
+    elem.target = "_blank";
+
+    repoCell.appendChild(elem);
+
+    tableRow.appendChild(repoCell);
+    VERSIONS.map((version) =>
+      tableRow.appendChild(createVersionCell(repoData, version))
+    );
+
+    tableElement.appendChild(tableRow);
+  });
+}
+
+async function main() {
+  // load data from the deployed directory
+  const dataArr = await loadData();
+
+  const repoData = {};
+
+  VERSIONS.map((version, i) =>
+    dataArr[i].include.forEach(({ repository, tag }) => {
+      repoData[repository] = {
+        ...repoData[repository],
+        [version]: tag,
+      };
+    })
+  );
+
+  // sort repo names alphabetically
+  const repoArr = Object.keys(repoData)
+    .sort()
+    .map((repo) => ({ repo, ...repoData[repo] }));
+
+  console.log(repoArr);
+
+  // populate table with versions
+  populateTable(repoArr);
+}
+
+main();

--- a/current/main.js
+++ b/current/main.js
@@ -4,7 +4,7 @@ async function loadData() {
   return await Promise.all(
     VERSIONS.map((version) =>
       fetch(
-        `https://graasp.github.io/graasp-deploy/deployed/current-${version}-versions.json`
+        `https://raw.githubusercontent.com/graasp/graasp-deploy/main/deployed/current-${version}-versions.json`
       ).then((res) => res.json())
     )
   );


### PR DESCRIPTION
This PR adds a view of the current deployments under `/current` in the github-pages deployement.

<img width="960" alt="Screenshot 2022-11-30 at 16 01 29" src="https://user-images.githubusercontent.com/39373170/204832715-15f110a3-fd39-4ecb-8a0e-07c5fab64e29.png">

closes #125 