### PR TITLE
fix: job race in auto-tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -27,6 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   tag-closed-issues:
+    needs: setup-labels
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.state_reason == 'completed' }}
     env:
@@ -41,6 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   untag-reopened-issues:
+    needs: setup-labels
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.state_reason == 'reopened' }}
     env:
@@ -55,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   tag-merged-prs:
+    needs: setup-labels
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged }}
     env:


### PR DESCRIPTION
This PR fixes an issue where on the first run the `setup-labels` job is run in parallel of the tagging jobs. This leads to failed workflow runs. Re-running the workflow usually solves it. But with this it should be better.
