### PR TITLE
fix: add `next-public-show-notifications` in library deploy workflows

### DIFF
--- a/.github/workflows/cdelivery-ecs-library.yml
+++ b/.github/workflows/cdelivery-ecs-library.yml
@@ -60,6 +60,8 @@ on:
         required: false
       next-public-domain:
         required: false
+      next-public-show-notifications:
+        required: false
       port:
         required: true
 
@@ -147,6 +149,7 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.next-public-sentry-dsn }}
             NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.next-public-ga-measurement-id }}
             NEXT_PUBLIC_DOMAIN=${{ secrets.next-public-domain }}
+            NEXT_PUBLIC_SHOW_NOTIFICATIONS=${{ secrets.next-public-show-notifications }}
             NEXT_PUBLIC_APP_NAME=${{ env.APP_NAME }}
             NEXT_PUBLIC_APP_VERSION=${{ env.APP_VERSION }}
             PORT=${{ secrets.port }}
@@ -172,7 +175,7 @@ jobs:
       with:
         ref: ${{ inputs.tag }}
 
-    # This step runs a single command to execute integation testing
+    # This step runs a single command to execute integration testing
     - name: Test
       run: |
         echo "This is the integration test step"

--- a/.github/workflows/cdeployment-ecs-library.yml
+++ b/.github/workflows/cdeployment-ecs-library.yml
@@ -60,6 +60,8 @@ on:
         required: false
       next-public-domain:
         required: false
+      next-public-show-notifications:
+        required: false
       port:
         required: true
 
@@ -146,6 +148,7 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.next-public-sentry-dsn }}
             NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.next-public-ga-measurement-id }}
             NEXT_PUBLIC_DOMAIN=${{ secrets.next-public-domain }}
+            NEXT_PUBLIC_SHOW_NOTIFICATIONS=${{ secrets.next-public-show-notifications }}
             NEXT_PUBLIC_APP_NAME=${{ env.APP_NAME }}
             NEXT_PUBLIC_APP_VERSION=${{ env.APP_VERSION }}
             PORT=${{ secrets.port }}

--- a/.github/workflows/cintegration-ecs-library.yml
+++ b/.github/workflows/cintegration-ecs-library.yml
@@ -56,6 +56,8 @@ on:
         required: false
       next-public-domain:
         required: false
+      next-public-show-notifications:
+        required: false
       port:
         required: true
 
@@ -179,6 +181,7 @@ jobs:
             NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.next-public-ga-measurement-id }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.next-public-sentry-dsn }}
             NEXT_PUBLIC_DOMAIN=${{ secrets.next-public-domain }}
+            NEXT_PUBLIC_SHOW_NOTIFICATIONS=${{ secrets.next-public-show-notifications }}
             NEXT_PUBLIC_APP_NAME=${{ env.APP_NAME }}
             NEXT_PUBLIC_APP_VERSION=${{ env.APP_VERSION }}
             PORT=${{ secrets.port }}


### PR DESCRIPTION
This PR adds the env var to toggle the `NEXT_PUBLIC_SHOW_NOTIFICATIONS` that controls whether the toasts are allowed.