### PR TITLE
chore: invert staging and prod schedule

### DIFF
--- a/.github/workflows/trigger-prod.yml
+++ b/.github/workflows/trigger-prod.yml
@@ -4,9 +4,9 @@ name: Deploy stack to prod
 
 # Controls when the action will run.
 on:
-  # Allow the workflow to be automatically triggered every Thursday at 9 a.m.
+  # Allow the workflow to be automatically triggered every Monday at 9 a.m.
   schedule:
-    - cron: '0 9 * * 4'
+    - cron: '0 9 * * 1'
   # Allow the workflow to be manually triggered
   workflow_dispatch:
     # Inputs the workflow accepts.

--- a/.github/workflows/trigger-stage.yml
+++ b/.github/workflows/trigger-stage.yml
@@ -4,9 +4,9 @@ name: Deploy stack to stage
 
 # Controls when the action will run.
 on:
-  # Allow the workflow to be automatically triggered every Monday at 9 a.m.
+  # Allow the workflow to be automatically triggered every Thursday at 9 a.m.
   schedule:
-    - cron: '0 9 * * 1'
+    - cron: '0 9 * * 4'
   # Allow the workflow to be manually triggered
   workflow_dispatch:
     # Inputs the workflow accepts.


### PR DESCRIPTION
This PR updates the auto-schedules for the staging and production deployments.

We will deploy Staging on Thursdays (9AM)
We will deploy prod on Mondays (9AM)

This will allow us to test staging during the weekend and fix any bugs we might encounter before pushing to prod on monday.
