### PR TITLE
fix: add pnpm install and cache action

### DIFF
--- a/.github/actions/pnpm-install-and-cache/action.yml
+++ b/.github/actions/pnpm-install-and-cache/action.yml
@@ -1,0 +1,29 @@
+name: Cache pnpm and install
+
+description: "PNPM install and cache modules"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v3
+      name: Install pnpm
+      with:
+        version: 9
+        run_install: false
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install


### PR DESCRIPTION
In this PR I create a composite action that can be used to install dependencies using pnpm. This workflow is similar to the `yarn-install-and-cache` but for pnpm.