### PR TITLE
fix: update-version cancels running workflows

### DIFF
--- a/.github/workflows/notify-new-candidate-version.yml
+++ b/.github/workflows/notify-new-candidate-version.yml
@@ -12,7 +12,9 @@ jobs:
     name: Update candidate version
     runs-on: ubuntu-latest
     # ensure only one instance of the workflow runs at a time
-    concurrency: notify-new-candidate
+    concurrency: 
+      group: notify-new-candidate
+      cancel-in-progress: false
     env:
       # REPO: repository that will update current version.
       REPO: ${{ github.event.client_payload.repository }}


### PR DESCRIPTION
If two new versions are dispatched to the repo nearly simultaneously then the first one will get cancelled by the second one. This is not expected, we want only a single one running, but the new one should not cancel the other. 