### PR TITLE
fix: update the compare script to emit a file even when there is no differences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# output from ci
+diff.json
+output.txt

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -1,6 +1,8 @@
 import json
 import sys
 
+DIFF_FILENAME = "diff.json"
+
 new = sys.argv[1]
 current = sys.argv[2]
 output = {}
@@ -46,9 +48,9 @@ if len(all_changes.keys()) > 0:
     with open("output.txt", "w") as out_log:
         out_log.write(out_string)
     # New file
-    with open("diff.json", "w") as output_file:
+    with open(DIFF_FILENAME, "w") as output_file:
         json.dump(output, output_file)
 else:
     print("No differences")
-    with open("no_diff.txt", "w") as out_log:
-        out_log.write("poop")
+    with open(DIFF_FILENAME, "w") as output_file:
+        json.dump({}, output_file)


### PR DESCRIPTION
In this PR:
- update the compare script to output a `diff.json` that is empty even when there are no changes.

This allows the CI logic to no break and to correctly output the "No changes 💩 detected" message.